### PR TITLE
Reset calculate button on early validation and add UI tests

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -197,6 +197,13 @@ async function handleCalculation(event) {
     const birthdateStr = birthdateInput.value;
     const sex = sexInput.value;
 
+    const finalizeCalculation = () => {
+        if (calculateBtn) {
+            calculateBtn.textContent = 'Calculate & Visualize';
+            updateButtonState();
+        }
+    };
+
     // --- Start Loading State ---
     if (calculateBtn) {
         calculateBtn.disabled = true; // Disable button immediately
@@ -225,6 +232,7 @@ async function handleCalculation(event) {
     if (!birthdateStr || !sex) {
         displayError('Please fill in both your birth date and sex.');
         renderCurrentView(); // Clear grid content area if validation fails
+        finalizeCalculation();
         return; // Exit, leaving only results area visible
     }
 
@@ -242,6 +250,7 @@ async function handleCalculation(event) {
     if (isNaN(birthDateUTC.getTime()) || birthDateUTC >= nowLocalMidnight) {
         displayError('Please enter a valid birth date in the past (YYYY-MM-DD).');
         renderCurrentView(); // Clear grid content area if validation fails
+        finalizeCalculation();
         return; // Exit, leaving only results area visible
     }
 
@@ -285,10 +294,7 @@ async function handleCalculation(event) {
         // Other elements (gridContainer, etc.) remain hidden (handled by reset at start)
     } finally {
         // --- End Loading State (always executed) ---
-        if (calculateBtn) {
-            calculateBtn.textContent = 'Calculate & Visualize'; // Revert button text
-            updateButtonState(); // Re-evaluate button's enabled/disabled state
-        }
+        finalizeCalculation();
     }
 }
 

--- a/tests/unit/ui.test.js
+++ b/tests/unit/ui.test.js
@@ -206,6 +206,67 @@ describe('ui module (setup & form flow)', () => {
     expect(form.classList.contains('hidden')).toBe(false);
   });
 
+  it('handleCalculation rejects future dates and skips calculations', async () => {
+    const { setupEventListeners } = await import('../../js/ui.js');
+    const calculator = await import('../../js/calculator.js');
+
+    setupEventListeners();
+
+    const form = document.getElementById('life-input-form');
+    const birthdateInput = document.getElementById('birthdate');
+    const sexSelect = document.getElementById('sex');
+    const resultsArea = document.getElementById('results-area');
+    const gridContainer = document.getElementById('life-grid-container');
+    const calculateBtn = document.getElementById('calculate-btn');
+
+    birthdateInput.value = '3000-01-01';
+    birthdateInput.dispatchEvent(new global.Event('input', { bubbles: true }));
+    sexSelect.value = 'male';
+    sexSelect.dispatchEvent(new global.Event('change', { bubbles: true }));
+
+    form.dispatchEvent(new global.Event('submit', { bubbles: true, cancelable: true }));
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(resultsArea.classList.contains('error-message')).toBe(true);
+    expect(resultsArea.textContent).toContain('Please enter a valid birth date in the past');
+    expect(gridContainer.classList.contains('hidden')).toBe(true);
+    expect(calculateBtn.textContent).toBe('Calculate & Visualize');
+    expect(calculator.calculateCurrentAge).not.toHaveBeenCalled();
+    expect(calculator.getRemainingExpectancy).not.toHaveBeenCalled();
+  });
+
+  it('handleCalculation shows error when expectancy data is unavailable', async () => {
+    const { setupEventListeners } = await import('../../js/ui.js');
+    const calculator = await import('../../js/calculator.js');
+
+    calculator.getRemainingExpectancy.mockResolvedValueOnce(null);
+
+    setupEventListeners();
+
+    const form = document.getElementById('life-input-form');
+    const birthdateInput = document.getElementById('birthdate');
+    const sexSelect = document.getElementById('sex');
+    const resultsArea = document.getElementById('results-area');
+    const gridContainer = document.getElementById('life-grid-container');
+    const startOverContainer = document.getElementById('start-over-container');
+
+    birthdateInput.value = '1990-01-01';
+    birthdateInput.dispatchEvent(new global.Event('input', { bubbles: true }));
+    sexSelect.value = 'male';
+    sexSelect.dispatchEvent(new global.Event('change', { bubbles: true }));
+
+    form.dispatchEvent(new global.Event('submit', { bubbles: true, cancelable: true }));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(resultsArea.classList.contains('error-message')).toBe(true);
+    expect(resultsArea.textContent).toContain('Could not retrieve life expectancy data');
+    expect(gridContainer.classList.contains('hidden')).toBe(true);
+    expect(startOverContainer.classList.contains('hidden')).toBe(true);
+    expect(form.classList.contains('hidden')).toBe(false);
+  });
+
   it('Start Over button resets the UI to initial state after success', async () => {
     const { setupEventListeners } = await import('../../js/ui.js');
 
@@ -280,5 +341,39 @@ describe('ui module (setup & form flow)', () => {
     // The second button should now be active and have aria-selected="true"
     expect(secondBtn.classList.contains('active')).toBe(true);
     expect(secondBtn.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('updates aria-labelledby and calls the correct renderer on view change', async () => {
+    const viewSwitcher = document.getElementById('view-switcher');
+    const secondBtn = document.createElement('button');
+    secondBtn.className = 'view-button';
+    secondBtn.id = 'view-months';
+    secondBtn.setAttribute('role', 'tab');
+    secondBtn.dataset.view = 'months';
+    viewSwitcher.appendChild(secondBtn);
+
+    const { setupEventListeners } = await import('../../js/ui.js');
+    const gridRenderer = await import('../../js/gridRenderer.js');
+
+    setupEventListeners();
+
+    const form = document.getElementById('life-input-form');
+    const birthdateInput = document.getElementById('birthdate');
+    const sexSelect = document.getElementById('sex');
+    const gridContentArea = document.getElementById('grid-content-area');
+
+    birthdateInput.value = '1990-01-01';
+    birthdateInput.dispatchEvent(new global.Event('input', { bubbles: true }));
+    sexSelect.value = 'male';
+    sexSelect.dispatchEvent(new global.Event('change', { bubbles: true }));
+    form.dispatchEvent(new global.Event('submit', { bubbles: true, cancelable: true }));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    secondBtn.dispatchEvent(new global.MouseEvent('click', { bubbles: true }));
+
+    expect(gridRenderer.renderMonthsGrid).toHaveBeenCalled();
+    expect(gridContentArea.getAttribute('aria-labelledby')).toBe('view-months');
+    expect(secondBtn.classList.contains('active')).toBe(true);
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent the calculate button from remaining stuck in the "Calculating..." state when input validation fails early in the UI flow.
- Increase test coverage for UI behaviors around validation, error handling, and view switching to ensure the app reacts correctly to invalid inputs and missing data.

### Description
- Add a `finalizeCalculation` helper in `js/ui.js` that restores the calculate button text and state, and call it from early validation branches and the `finally` block to guarantee reset on all exit paths.
- Ensure early validation branches for empty inputs and future/invalid birthdates call the new finalizer so the UI is left in a consistent state.
- Expand `tests/unit/ui.test.js` with three new tests that assert rejection of future birthdates and that calculator functions are not called, simulate missing expectancy data to verify error handling, and validate that view switching updates `aria-labelledby` and calls the correct renderer.
- Changes touch `js/ui.js` and `tests/unit/ui.test.js` to implement the fix and the additional tests.

### Testing
- Ran the full test suite with `npm test -- --run` and iterated until green; the final run reported all tests passing (`47 passed`).
- The new and existing unit tests include `tests/unit/ui.test.js` (updated), `tests/unit/calculator.test.js`, and multiple `gridRenderer` unit tests which all executed successfully during the run.
- Verified the failing UI behavior locally in tests and confirmed the `calculate` button state no longer remains `"Calculating..."` after early validation exits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985d9ff02b0832db67e8f2daa1099c1)