### PR TITLE
Sync `aria-hidden` for grid axis labels when showing/hiding

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -83,12 +83,16 @@ function updateAxisLabels(show, topText = '', leftText = '') {
             gridAxisLabelLeft.innerHTML = `&lt;----- ${leftText} ------`;
             gridAxisLabelTop.classList.remove('hidden');
             gridAxisLabelLeft.classList.remove('hidden');
+            gridAxisLabelTop.setAttribute('aria-hidden', show ? 'false' : 'true');
+            gridAxisLabelLeft.setAttribute('aria-hidden', show ? 'false' : 'true');
             // Show the wrapper which contains the left axis label and the grid content area.
             gridContentWrapper.classList.remove('hidden'); 
         } else { // Hiding labels
             gridAxisLabelTop.classList.add('hidden');
             gridAxisLabelLeft.classList.add('hidden');
             gridContentWrapper.classList.add('hidden');
+            gridAxisLabelTop.setAttribute('aria-hidden', show ? 'false' : 'true');
+            gridAxisLabelLeft.setAttribute('aria-hidden', show ? 'false' : 'true');
             gridAxisLabelTop.innerHTML = ''; // Clear text when hidden
             gridAxisLabelLeft.innerHTML = '';
         }


### PR DESCRIPTION
### Motivation
- Ensure assistive technologies receive the correct visibility state for the grid axis labels by updating `aria-hidden` whenever the labels are shown or hidden.

### Description
- In `js/ui.js` inside `updateAxisLabels` add `gridAxisLabelTop.setAttribute('aria-hidden', show ? 'false' : 'true')` and `gridAxisLabelLeft.setAttribute('aria-hidden', show ? 'false' : 'true')` in both the show and hide branches so the attribute stays in sync with visual state.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985df697adc832db2805188dab5e874)