### PR TITLE
Use deterministic UTC parsing for birth dates

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -236,18 +236,22 @@ async function handleCalculation(event) {
         return; // Exit, leaving only results area visible
     }
 
-    // Create Date object from input string
-    const birthDateLocal = new Date(birthdateStr);
-
-    // **CRITICAL: Normalize date to UTC midnight.**
-    const birthDateUTC = new Date(birthDateLocal.getTime()); // Clone first
-    birthDateUTC.setMinutes(birthDateUTC.getMinutes() + birthDateUTC.getTimezoneOffset());
+    // Create Date object from input string deterministically in UTC.
+    const [yearStr, monthStr, dayStr] = birthdateStr.split('-');
+    const year = Number(yearStr);
+    const monthIndex = Number(monthStr) - 1;
+    const day = Number(dayStr);
+    const birthDateUTC = new Date(Date.UTC(year, monthIndex, day));
 
     const now = new Date();
-    const nowLocalMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const isValidBirthDate = !Number.isNaN(birthDateUTC.getTime()) &&
+        birthDateUTC.getUTCFullYear() === year &&
+        birthDateUTC.getUTCMonth() === monthIndex &&
+        birthDateUTC.getUTCDate() === day;
 
-    // Check validity *after* potential normalization and ensure date is in the past.
-    if (isNaN(birthDateUTC.getTime()) || birthDateUTC >= nowLocalMidnight) {
+    // Check validity and ensure date is in the past.
+    if (!isValidBirthDate || birthDateUTC >= todayUTC) {
         displayError('Please enter a valid birth date in the past (YYYY-MM-DD).');
         renderCurrentView(); // Clear grid content area if validation fails
         finalizeCalculation();


### PR DESCRIPTION
### Motivation
- Prevent timezone-dependent validation and calculation errors by avoiding local-time `Date` parsing and `getTimezoneOffset` adjustments.

### Description
- In `handleCalculation` (in `js/ui.js`) replace the local-`Date` + `getTimezoneOffset` normalization with deterministic UTC parsing by splitting the input and calling `new Date(Date.UTC(year, monthIndex, day))`.
- Validate the parsed date by comparing parsed year/month/day components to the created UTC `Date` to catch invalid inputs (e.g. `2021-02-30`).
- Compare the parsed birth date against a UTC "today" computed with `Date.UTC` to ensure the date is strictly in the past.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985df633f54832dacc6ca752b7eb32d)