### PR TITLE
Fix calendar week calculations and reset validation behavior

### DIFF
--- a/.kilocode/rules/memory-bank/activeContext.md
+++ b/.kilocode/rules/memory-bank/activeContext.md
@@ -1,42 +1,37 @@
 # Active Context — Life Visualized
 
 ## Last Update
-- Date: 2026-03-25
-- Summary: Branch test expansion pass completed. Coverage increased substantially with focused `ui`/`gridRenderer`/`calculator` tests, then low-value duplicate tests were pruned.
+- Date: 2026-07-27
+- Summary: Behavior audit refinements completed for input validation, Start Over state, and timezone-independent ISO Calendar weeks.
 
 ## Recent Changes
-- Upgraded dev deps:
-  - `vitest` -> `^4.1.1`
-  - `jsdom` -> `^29.0.1`
-  - `c8` -> `^11.0.0`
-- Added quality gate tooling and config:
-  - `eslint`, `@eslint/js`, `globals`
-  - `typescript`, `@types/node`
-  - `eslint.config.js`, `tsconfig.json`, `types/globals.d.ts`
-- Updated CI workflow to run:
-  - `npm ci`
-  - `npm run lint`
-  - `npm run typecheck`
-  - `npm run test:run`
-- Updated tests for Vitest 4 mocking semantics (`vi.doMock(...)` where needed).
-- Expanded branch-focused coverage tests across:
+- Added immediate birthdate validation:
+  - `#birthdate.max` is set to yesterday using the browser's local calendar date.
+  - Today, future dates, malformed dates, and incomplete forms keep Calculate disabled.
+  - Submit-time validation remains as a defensive check.
+- Expanded Start Over into a complete initial-state reset:
+  - Clears inputs, results, calculation data, grid content, and error styling.
+  - Restores Weeks (Age) as the active view with synchronized `aria-selected`, `tabindex`, and `aria-labelledby`.
+  - Successful calculations focus the selected tab instead of always focusing the first tab.
+- Replaced Calendar view's local-time `date-fns` ISO calculations with deterministic UTC helpers:
+  - Correct 52/53-week counts and Monday week starts across browser timezones.
+  - UTC-safe title formatting no longer depends on `date-fns-tz`.
+  - Fractional lifespan endpoints are retained using month-based UTC arithmetic.
+- Added regression coverage in:
   - `tests/unit/ui.test.js`
-  - `tests/unit/calculator.test.js`
   - `tests/unit/gridRenderer.calendar.test.js`
-  - `tests/unit/gridRenderer.months.test.js`
-  - `tests/unit/gridRenderer.years.test.js`
-  - `tests/unit/gridRenderer.failure.test.js`
-- Pruned low-value test overlap:
-  - Removed `tests/unit/data-inspect.test.js` (debug-only).
-  - Removed duplicate invalid-sex assertion in `calculator.test.js`.
-- Current local test baseline: 11 files / 67 tests passing.
+- Created GitHub tracking:
+  - Issue #31: Calendar/Birthday week-alignment toggle (backlog enhancement).
+  - Issue #32: Incorrect ISO Calendar week counts/dates (fixed locally; open pending merge).
+- Current local test baseline: 11 files / 69 tests passing.
 - Current local coverage baseline:
-  - Statements `96.32%`
-  - Branches `78.84%`
+  - Statements `96.17%`
+  - Branches `81.97%`
   - Functions `100%`
-  - Lines `97.8%`
+  - Lines `97.74%`
 
 ## Next Steps
-- Push branch changes and open PR with updated coverage summary.
+- Commit and merge the current behavior refinements; close issue #32 after the fix reaches `main`.
+- Implement issue #31 with Calendar weeks as the default alignment.
+- Address remaining timezone-sensitive Month/Year renderer operations and the unavailable `date-fns-tz` runtime global identified during the audit.
 - Decide whether to enforce minimum branch coverage in CI.
-- Keep focused refactor work scoped to high-complexity modules (`js/ui.js`, `js/gridRenderer.js`) while preserving current test baseline.

--- a/.kilocode/rules/memory-bank/architecture.md
+++ b/.kilocode/rules/memory-bank/architecture.md
@@ -19,7 +19,7 @@
 * **Vanilla JavaScript (ES Modules):** Chosen for simplicity and performance, avoiding framework overhead for this specific application scope. Enables clear separation of concerns via modules.
 * **UTC-Based Date Handling:**
   * **Decision:** All internal date storage and calculations are performed using UTC to ensure consistency and avoid timezone/DST errors.
-  * **Pattern:** Input date string is normalized to a UTC midnight Date object in `ui.js`. This normalized object is stored and passed to `gridRenderer.js`, which uses `date-fns` functions configured for UTC.
+  * **Pattern:** Input date strings are validated against the user's local calendar date, then normalized to UTC midnight in `ui.js`. Calendar ISO boundaries are calculated with native UTC helpers; other renderers still use global `date-fns` operations.
 * **UI State Management (`ui.js`):**
   * **Pattern:** Simple module-level variables (`currentView`, `lastCalcData`) are used to maintain the selected view and the results of the last calculation.
   * **Rationale:** Sufficient for the current application state; avoids the complexity of a dedicated state management library. Enables efficient view switching without recalculation.
@@ -68,7 +68,7 @@
     1. `ui.js` (`renderCurrentView`) determines the view type (`currentView`).
     2. `ui.js` calls the appropriate function in `gridRenderer.js` (e.g., `renderMonthsGrid`), passing `lastCalcData` and the specific `#grid-content-area` element. (UPDATED)
     3. `gridRenderer.js` function clears the *provided element's* (`#grid-content-area`) content. (UPDATED)
-    4. `gridRenderer.js` performs UTC date calculations using `date-fns`.
+    4. `gridRenderer.js` performs date calculations; Calendar view uses native UTC ISO helpers while other views currently use `date-fns`.
     5. `gridRenderer.js` generates DOM elements (rows, blocks) with correct classes/attributes.
     6. `gridRenderer.js` appends elements to the *provided element* (`#grid-content-area`). (UPDATED)
     7. `gridRenderer.js` sets the `aria-label` on the *parent* (`#life-grid-container`) for overall context. (UPDATED)
@@ -81,9 +81,9 @@
 ## 4. Critical Implementation Details
 
 * **`gridRenderer.js` - Age View Week Logic:** Uses `eachWeekOfInterval` + `filter(isBefore)` + `.pop()` (if length 54) to accurately determine the ISO weeks starting within each year of life, ensuring visual consistency (max 53 weeks/row).
-* **`gridRenderer.js` - Calendar View:** Uses `getISOWeeksInYear` and correctly handles the 52/53 week variation. Applies `out-of-bounds` styling based on comparison with `firstWeekStartDateUTC` and `estimatedEndDateUTC`.
+* **`gridRenderer.js` - Calendar View:** Calculates ISO week-year boundaries directly from UTC date components and correctly handles the 52/53 week variation without browser-timezone drift. Applies `out-of-bounds` styling based on comparison with `firstWeekStartDateUTC` and `estimatedEndDateUTC`.
 * **CSS `calc()` + `aspect-ratio`:** The core mechanism for ensuring Month/Year blocks fill the fixed container width while remaining square. Formulas must be updated in media queries if gaps change.
-* **`js/ui.js` - `handleViewChange()`:** Logic handles clicks on `.view-button` elements, reads `data-view`, manages `.active` class and `aria-checked` attributes.
+* **`js/ui.js` - `handleViewChange()`:** Logic handles clicks on `.view-button` elements, reads `data-view`, and manages `.active`, `aria-selected`, `tabindex`, and tabpanel `aria-labelledby` attributes.
 * **`index.html` - `#grid-content-area`:** A dedicated `div` within `#life-grid-container` that serves as the specific target for grid rendering, preventing clearing of other nested elements like the header and guide. (NEW)
 * **CSS - `position: sticky`:** Applied to `#grid-controls-header` to keep it visible at the top of the scrollable `#life-grid-container`. (NEW)
 * **CSS - `.view-button` Styling:** Uses `white-space: normal` to allow wrapping and `min-height` to ensure consistent vertical size for all buttons, combined with `display: inline-flex` and `align-items: center` for vertical text centering. (NEW)
@@ -99,9 +99,9 @@
 * **No Section Headings:** Explicit `<h2>` headings for "Results" and "Visualization" were removed as the content flow makes their purpose clear, reducing visual noise.
 * **Constrained Width Alignment:** The main grid container and the results area share the same `max-width` and are centered within the main container, creating a visually cohesive block post-calculation. (UPDATED)
   * The overall page `.container` `max-width` has been reduced, and `body` padding adjusted for better large-screen aesthetics. (NEW)
-* **Dynamic Button State:** The "Calculate & Visualize" button is disabled until both birth date and sex inputs are valid. (NEW)
+* **Dynamic Button State:** The "Calculate & Visualize" button is disabled until both fields are complete and the birthdate is before the user's local calendar date. The input `max` is set to yesterday. (UPDATED)
 * **Loading Indicators:** The "Calculate & Visualize" button text changes to "Calculating..." and the results area displays a loading message during processing. (NEW)
-* **"Start Over" Functionality:** A dedicated button allows users to reset the application to its initial input state. (NEW)
+* **"Start Over" Functionality:** A dedicated button clears calculation/UI state, restores Weeks (Age) and synchronized tab ARIA state, disables Calculate, and focuses the birthdate field. (UPDATED)
 * **Responsive Results Area:** Vertical padding and margins within the results area are reduced on smaller screens to conserve space. (NEW)
 
 ## 6. Development History and UX Refinements

--- a/.kilocode/rules/memory-bank/context.md
+++ b/.kilocode/rules/memory-bank/context.md
@@ -1,54 +1,59 @@
 # Current Context - Life Visualized
 
 ## Current Goal
-Maintain a stable, high-signal test baseline with stronger branch coverage and minimal test noise.
+Keep all visualization and UI state behavior deterministic across browser timezones while maintaining a high-signal test baseline.
 
 ## Current Task
-Test-suite value review, duplicate/obsolete test cleanup, and docs/memory-bank synchronization.
+Document and prepare the audited behavior refinements for commit and review.
 
 ## Recent Changes
 
-- Expanded branch-focused test coverage across `ui`, `calculator`, and `gridRenderer` unit suites.
-- Added deterministic tests for view-switching keyboard paths, renderer catch paths, fallback DOM branches, and calculator bracket-fallback edge cases.
-- Removed low-value overlap from the suite:
-  - `tests/unit/data-inspect.test.js` deleted (debug-only assertions duplicated by data integrity tests).
-  - Duplicate `nonbinary` invalid-sex assertion removed from `calculator.test.js`.
+- Added immediate birthdate validation and a local-calendar `max` of yesterday.
+- Start Over now restores the complete initial state, including Weeks (Age) selection and ARIA state.
+- Calendar view now computes ISO week years, week starts, and 52/53-week counts directly in UTC.
+- Added deterministic regression tests for known ISO boundaries and fractional lifespan endpoints.
+- Opened:
+  - Issue #31 for a future Calendar/Birthday week-alignment toggle.
+  - Issue #32 for the Calendar timezone bug fixed by the current changes.
 - Local baseline validated:
-  - `npm run verify` -> 67/67 tests passing
-  - `npm run test:coverage` -> 96.32% statements, 78.84% branches, 100% functions, 97.8% lines
+  - `npm run verify` -> 69/69 tests passing
+  - `npm run test:coverage` -> 96.17% statements, 81.97% branches, 100% functions, 97.74% lines
 
 ## Next Action
-Commit branch with test cleanup + coverage updates and open PR.
+Commit the behavior fixes and documentation updates, then merge and close issue #32.
 
 ## Decisions
 - Adopted Node 20 as CI baseline due to `vitest@4` engine requirements.
 - Added lint + typecheck gates in CI before tests.
 - Typecheck gate currently uses TypeScript project validation without JS strict checking (`checkJs: false`) to keep signal actionable.
 - Keep defensive-but-unreachable renderer warning branches as known residual coverage gaps rather than forcing brittle synthetic tests.
+- Use the browser's local calendar date for user-facing birthdate validity, while normalizing accepted date-only values to UTC.
+- Keep Calendar weeks as the default alignment; track Birthday-aligned weeks separately in issue #31.
+- Compute Calendar ISO boundaries with native UTC helpers instead of local-time `date-fns` functions.
 
 ## Blockers
 None.
 
 ## Relevant Files Recently Modified
-- `.github/workflows/ci.yml`
-- `package.json`
-- `package-lock.json`
-- `eslint.config.js`
-- `tsconfig.json`
-- `types/globals.d.ts`
+- `js/ui.js`
+- `js/gridRenderer.js`
 - `tests/unit/ui.test.js`
-- `tests/unit/ui.axis-aria.test.js`
-- `tests/unit/main.test.js`
+- `tests/unit/gridRenderer.calendar.test.js`
 - `README.md`
-- `docs/2026-03-25-changes.md`
+- `docs/ui.md`
+- `docs/gridRenderer.md`
+- `docs/2026-07-27-changes.md`
 - `.kilocode/rules/memory-bank/activeContext.md`
+- `.kilocode/rules/memory-bank/architecture.md`
 - `.kilocode/rules/memory-bank/progress.md`
+- `.kilocode/rules/memory-bank/tech.md`
 - `.kilocode/rules/memory-bank/tests-plans-by-module.md`
 
 ## Open Questions/Decisions
 - Should CI include coverage thresholds (`npm run test:coverage`) as an additional gate?
 - Should the project adopt stricter type checking over time (e.g., gradual `checkJs` opt-in per file)?
-- Should Dependabot auto-merge policy be enabled for low-risk devDependency patches?
+- Should the optional `date-fns-tz` CDN integration be repaired, upgraded, or removed in favor of native UTC helpers?
+- How should Month and Year views be migrated away from local-time `date-fns` arithmetic?
 
 ## Learnings & Insights
 

--- a/.kilocode/rules/memory-bank/product.md
+++ b/.kilocode/rules/memory-bank/product.md
@@ -20,7 +20,7 @@ It is **not** intended as a precise predictive tool but rather as a thought-prov
   * **Clarity:** The visualization should be immediately understandable. The grid, colors, and states (past/present/future) should be intuitive. Explanations and keys should be easily accessible when needed. The current view should be clearly indicated.
   * **Simplicity:** The initial interaction should be focused and straightforward (enter details, calculate). Complexity is revealed progressively.
   * **Impact:** The visualization should be striking and encourage contemplation. Placing the grid prominently after results enhances impact.
-  * **Accuracy (within scope):** Calculations should correctly reflect age and use the specified actuarial data. Date handling (especially across timezones/DST) must be robust (achieved via UTC normalization and calculation).
+  * **Accuracy (within scope):** Calculations should correctly reflect age and use the specified actuarial data. Date handling across timezones/DST must be deterministic; Calendar weeks now meet this requirement, while Month/Year follow-up remains tracked in current context.
   * **Responsiveness:** The experience should be seamless across desktop, tablet, and mobile devices.
   * **Transparency:** Explanations for visualization nuances (53-week years, calendar view) and a clear disclaimer about the nature of the estimates are essential.
   * **Visual Cohesion:** Controls and related information should feel integrated with the visualization they affect.
@@ -33,7 +33,8 @@ It is **not** intended as a precise predictive tool but rather as a thought-prov
     * The page displays the Title, a brief introductory sentence, the Input Form (DOB, Sex, Calculate button), and the Disclaimer.
     * Results Area and the main Grid Container (`#life-grid-container`) are hidden. The Grid Container holds the Grid Controls Header, Grid Guide section, and the Grid Content Area, all of which are also initially hidden.
 2. **User Interaction:**
-    * User enters their birth date and selects their sex from the form. Button enables dynamically.
+    * User enters their birth date and selects their sex from the form.
+    * Calculate enables only when both fields are complete and the birthdate is before the user's local calendar date. The date control limits selection to yesterday or earlier.
     * User clicks the "Calculate & Visualize" button.
 3. **Calculation Attempt & Results Display:**
     * Button text changes to "Calculating...", results area shows "Calculating your timeline...".
@@ -53,7 +54,7 @@ It is **not** intended as a precise predictive tool but rather as a thought-prov
     * Selecting a different view instantly updates the grid visualization in the grid content area *without* requiring recalculation. The active button style updates.
     * The Grid Controls Header remains sticky at the top of the grid container as the user scrolls horizontally or vertically within the grid area.
     * The user can expand/collapse the "How to Read This Visualization" section (`<details>`) to view the explanation ("Understanding the Grid") and color key ("What the Colors Mean"), presented in side-by-side columns (which stack vertically on smaller screens).
-    * The "Start Over" button is visible after the grid container. Clicking it hides the results, grid, and "Start Over" button, clears inputs, shows the form, and resets the "Calculate & Visualize" button to disabled.
+    * The "Start Over" button is visible after the grid container. Clicking it hides and clears the results and grid, clears calculation data and inputs, restores Weeks by Age as the selected view with matching ARIA state, shows the form, disables Calculate, and focuses the birthdate field.
 5. **Re-Calculation:** If the user changes inputs and clicks "Calculate & Visualize" again, the flow repeats from Step 2/3 (relevant sections are hidden again before the new attempt).
 
 ## 4. Key Product Decisions (Rationale) - Updated for Refinements
@@ -68,7 +69,7 @@ It is **not** intended as a precise predictive tool but rather as a thought-prov
 * **Fixed Grid Container Width:** Ensures a stable and predictable user experience when switching between views.
 * **Dynamic Block Sizing (Months/Years):** Makes less granular views visually fill the available space effectively.
 * **Clear Disclaimer & Explanations:** Manages user expectations and clarifies visualization nuances.
-* **UTC Date Handling:** Ensures consistent calculations free from local timezone/DST ambiguities.
+* **UTC Date Handling:** Accepted date-only input is normalized to UTC. Calendar view computes ISO week-year boundaries directly from UTC date components so 52/53-week counts and Monday starts do not drift with browser timezone.
 * **Progressive Reveal:** Creates a cleaner starting point focused on input.
 * **Consolidated & Collapsible Guide/Key:** Keeps secondary information accessible but visually tidy. Explanation text refined for clarity and user-friendliness.
 * **Integrated & Nested Controls Header:** Creates a strong visual connection between controls and visualization. Tooltips reduce clutter.

--- a/.kilocode/rules/memory-bank/progress.md
+++ b/.kilocode/rules/memory-bank/progress.md
@@ -1,74 +1,55 @@
 # Progress Log - Life Visualized
 
-## Latest Update (2026-03-25)
+## Latest Update (2026-07-27)
 - Status: Active
-- Summary: Test-coverage expansion completed with targeted branch tests and follow-up test-suite pruning of low-value duplicates.
+- Summary: Behavior audit fixes completed for immediate validation, full reset behavior, and timezone-independent Calendar weeks.
 
 ## Recent Changes
-- Dependabot-related upgrades applied to dev tooling in [`package.json`](package.json:1):
-  - `vitest` -> `^4.1.1`
-  - `jsdom` -> `^29.0.1`
-  - `c8` -> `^11.0.0`
-- Added quality-gate scripts:
-  - `lint`, `typecheck`, `verify`
-- Added lint/typecheck configuration:
-  - [`eslint.config.js`](eslint.config.js:1)
-  - [`tsconfig.json`](tsconfig.json:1)
-  - [`types/globals.d.ts`](types/globals.d.ts:1)
-- CI workflow updated in [`.github/workflows/ci.yml`](.github/workflows/ci.yml:1):
-  - Node version matrix moved to `20.x`
-  - Runs `npm run lint`, `npm run typecheck`, and `npm run test:run`
-- Updated test mocking style for Vitest 4 compatibility in:
-  - [`tests/unit/ui.test.js`](tests/unit/ui.test.js:1)
-  - [`tests/unit/ui.axis-aria.test.js`](tests/unit/ui.axis-aria.test.js:1)
-  - [`tests/unit/main.test.js`](tests/unit/main.test.js:1)
-- Expanded branch-focused tests in:
-  - [`tests/unit/ui.test.js`](tests/unit/ui.test.js:1)
-  - [`tests/unit/calculator.test.js`](tests/unit/calculator.test.js:1)
-  - [`tests/unit/gridRenderer.calendar.test.js`](tests/unit/gridRenderer.calendar.test.js:1)
-  - [`tests/unit/gridRenderer.months.test.js`](tests/unit/gridRenderer.months.test.js:1)
-  - [`tests/unit/gridRenderer.years.test.js`](tests/unit/gridRenderer.years.test.js:1)
-  - [`tests/unit/gridRenderer.failure.test.js`](tests/unit/gridRenderer.failure.test.js:1)
-- Removed low-value/duplicate tests:
-  - Deleted [`tests/unit/data-inspect.test.js`](tests/unit/data-inspect.test.js:1) (debug-only)
-  - Removed duplicate invalid-sex assertion from calculator test suite
+- Immediate input validation added in [`js/ui.js`](js/ui.js:1):
+  - Birthdate maximum is yesterday in the browser's local calendar.
+  - Calculate remains disabled for today, future, malformed, or incomplete input.
+- Start Over now resets inputs, results, renderer data, selected view, ARIA state, and focus.
+- Calendar rendering corrected in [`js/gridRenderer.js`](js/gridRenderer.js:1):
+  - Native UTC ISO week helpers replace timezone-sensitive local `date-fns` calculations.
+  - 52/53-week counts and Monday start dates are deterministic.
+  - Fractional lifespan endpoints and UTC-formatted titles are preserved.
+- GitHub issues created:
+  - #31 Add week-alignment toggle for age-based visualization.
+  - #32 Fix incorrect ISO week counts and dates in Calendar view.
 
 ## New/Updated Test Files
-- `tests/unit/ui.test.js` (Vitest 4 mock semantics)
-- `tests/unit/ui.axis-aria.test.js`
-- `tests/unit/main.test.js`
-- `tests/unit/calculator.test.js` (fallback/error-path coverage expansion)
-- `tests/unit/gridRenderer.calendar.test.js` (calendar edge/error branch coverage)
-- `tests/unit/gridRenderer.months.test.js` (skip-path branch coverage)
-- `tests/unit/gridRenderer.years.test.js` (skip/error branch coverage)
-- `tests/unit/gridRenderer.failure.test.js` (renderer catch-path coverage)
+- `tests/unit/ui.test.js` (immediate date validation and complete reset state)
+- `tests/unit/gridRenderer.calendar.test.js` (known ISO 52/53-week boundaries, unique starts, fractional endpoints)
 
 ## Completed Tasks
-- Completed dev-tooling upgrade and lockfile refresh.
-- Added lint and typecheck quality gates locally and in CI.
-- Updated CI to Node 20 baseline required by current test tooling.
-- Expanded and stabilized branch coverage with deterministic unit tests.
-- Removed redundant/diagnostic tests to improve suite signal.
-- Local verification succeeds via `npm run verify` (67/67 tests pass).
+- Audited primary UI flows in the local browser.
+- Fixed inactive-tab focus after recalculation.
+- Implemented full Start Over reset behavior.
+- Implemented immediate birthdate validity feedback.
+- Fixed Calendar view ISO week calculations across timezones.
+- Verified known ISO years in the Pacific-time browser runtime.
+- Local verification succeeds via `npm run verify` (69/69 tests pass).
 
 ## Remaining Work / Next Steps
-- Confirm Dependabot alert closure after push/merge to default branch.
+- Commit and merge current changes; close issue #32 after merge.
+- Implement issue #31 while keeping Calendar weeks as the default.
+- Correct remaining Month/Year timezone-sensitive date operations.
+- Decide whether to repair/remove the unavailable `date-fns-tz` browser global.
 - Decide whether to add coverage threshold enforcement in CI (branch threshold candidate).
-- Incrementally reduce module complexity in `js/ui.js` / `js/gridRenderer.js` while preserving behavior.
 
 ## Test Summary (current)
 - Commands:
   - `npm run verify`
   - `npm run test:run`
   - `npm run test:coverage`
-- Current result summary: 67 tests passing locally (0 failing), 11 test files.
+- Current result summary: 69 tests passing locally (0 failing), 11 test files.
 - Current coverage summary:
-  - Statements: `96.32%`
-  - Branches: `78.84%`
+  - Statements: `96.17%`
+  - Branches: `81.97%`
   - Functions: `100%`
-  - Lines: `97.8%`
+  - Lines: `97.74%`
 
 ## Notes
 - Local quality checks now have a single entrypoint (`npm run verify`) suitable for pre-PR runs.
 - CI now enforces lint/typecheck/tests in sequence for stronger baseline confidence.
-- Runtime app architecture is still static + CDN-based; current security updates were focused on dev/test dependency paths.
+- Runtime app architecture remains static + CDN-based, but Calendar ISO calculations no longer rely on timezone library behavior.

--- a/.kilocode/rules/memory-bank/tech.md
+++ b/.kilocode/rules/memory-bank/tech.md
@@ -10,12 +10,13 @@
 
 * **Runtime CDN dependencies:**
   * **`date-fns` v4.1.0:**
-  * **Usage:** Essential for all complex date calculations (getting weeks, adding units, formatting, comparing dates, handling ISO weeks/years).
+  * **Usage:** Used by Age, Month, and Year renderers for date calculations and by renderers for date comparisons.
   * **Integration:** Loaded via CDN (`https://cdn.jsdelivr.net/npm/date-fns@4.1.0/cdn.min.js`) in `index.html`. Accessed globally via the `dateFns` object.
   * **Constraint:** The application relies on this specific version (or compatible 4.x) being available globally. `gridRenderer.js` includes a basic check for its presence.
   * **`date-fns-tz` v1.3.7:**
-  * **Usage:** Optional timezone-aware helpers (`utcToZonedTime`, `formatInTimeZone`) used by renderer fallback paths.
+  * **Usage:** Intended as an optional timezone-aware formatting helper. Calendar view no longer depends on it and formats UTC dates directly.
   * **Integration:** Loaded via CDN (`https://cdn.jsdelivr.net/npm/date-fns-tz@1.3.7/dist/date-fns-tz.min.js`) in `index.html`. Accessed globally via `dateFnsTz`.
+  * **Known runtime state:** The current CDN script does not expose `dateFnsTz` in the audited browser runtime, so remaining renderers use their core `date-fns` fallback paths.
 
 * **Dev/test dependencies (npm):**
   * `vitest` `^4.1.1`
@@ -46,15 +47,15 @@
   * Local coverage: `npm run test:coverage`
   * CI: `.github/workflows/ci.yml` runs `npm ci`, `npm run lint`, `npm run typecheck`, `npm run test:run`
 
-## 6. Current Test/Coverage Baseline (2026-03-25)
+## 6. Current Test/Coverage Baseline (2026-07-27)
 
 * Unit test files: `11`
-* Passing tests: `67`
+* Passing tests: `69`
 * Coverage:
-  * Statements: `96.32%`
-  * Branches: `78.84%`
+  * Statements: `96.17%`
+  * Branches: `81.97%`
   * Functions: `100%`
-  * Lines: `97.8%`
+  * Lines: `97.74%`
 ## 7. Additional Notes from Historical Context
 
 * The project has undergone multiple iterations of UX refinement focusing on clarity, simplicity, and accessibility.

--- a/.kilocode/rules/memory-bank/tests-plans-by-module.md
+++ b/.kilocode/rules/memory-bank/tests-plans-by-module.md
@@ -37,12 +37,12 @@ Brief: Separate, focused test plans for each core module to keep the memory bank
 - Tests:
   1. Helpers: `getLifeStageKey` boundary checks; `calculateAgeAtDate` correctness across UTC dates.
   2. `renderAgeGrid`: enforce max 53 weeks when `eachWeekOfInterval` yields 54; confirm past/present/future classes.
-  3. `renderCalendarGrid`: ISO week/year handling (52/53), out-of-bounds weeks, per-week age/stage correctness.
+  3. `renderCalendarGrid`: native UTC ISO week/year handling for known 52/53-week years, unique Monday starts, fractional lifespan endpoints, out-of-bounds weeks, and per-week age/stage correctness.
   4. `renderMonthsGrid`: 12 months per row; month state classification and life stage assignment.
   5. `renderYearsGrid`: decade rows (10/year); current year highlighting; state classes.
   6. Failure modes: missing `dateFns` -> DOM shows error-message; missing DOM element param -> no throw.
-  7. Per-week calendar fallback: one ISO week computation failure logs error and rendering continues for remaining weeks.
-- Test notes: Use JSDOM; mock global.dateFns with minimal functions required by each test to keep tests deterministic and fast.
+  7. Timezone regression: known ISO boundaries must produce identical counts/titles without relying on mocked `getISOWeeksInYear` values.
+- Test notes: Use JSDOM; mock only the remaining global `dateFns` comparison/functions required by each renderer. Calendar ISO boundaries should exercise the production UTC helpers.
 - Estimated effort: 6–12 tests
 
 ## js/ui.js
@@ -50,14 +50,14 @@ Brief: Separate, focused test plans for each core module to keep the memory bank
 - Primary file: [`js/ui.js`](js/ui.js:1)
 - Priority: Medium
 - Tests:
-  1. `areInputsValid` / `updateButtonState`: enabling/disabling logic and button title.
+  1. `areInputsValid` / `updateButtonState`: enabling/disabling logic, button title, yesterday `max`, and rejection of today/future dates.
   2. `handleCalculation` success path: mock `calculateCurrentAge` and `getRemainingExpectancy` to confirm results rendering, `lastCalcData` set, progressive reveal (form hidden, grid shown).
   3. `handleCalculation` error paths: invalid date input, future date, expectancy returns null -> displayError and grid stays hidden.
   4. `renderCurrentView`: clears content when no data; sets aria-label/tabindex when rendered; adds view-specific class to container.
   5. `renderCurrentView` fallback/error paths: missing `#grid-content-area` -> grid layout error fallback, renderer exception -> error message and aria cleanup.
   6. `handleViewChange`: updates `currentView`, toggles `.active` and ARIA attributes, re-renders; unknown view shows invalid-view error.
   7. Keyboard tablist navigation: Arrow/Home/End handling, wrap-around, non-tab focus guard, unhandled key no-op.
-  8. `handleStartOver`: resets inputs, hides containers, clears `lastCalcData`.
+  8. `handleStartOver`: resets inputs/results/data, hides containers, restores Weeks (Age), synchronizes tab ARIA state, and returns focus to birthdate.
 - Test notes: Build DOM fixture using snippets from [`index.html`](index.html:1); stub imported calculator functions; use vi.resetModules() and vi.mock() for isolation.
 - Estimated effort: 8–14 tests
 
@@ -79,14 +79,14 @@ Brief: Separate, focused test plans for each core module to keep the memory bank
 - Test notes: Use real modules but mock `dateFns` and `lifeExpectancyData` as needed; run in JSDOM.
 - Estimated effort: 3–5 tests
 
-## Current Status Snapshot (2026-03-25)
+## Current Status Snapshot (2026-07-27)
 - Unit test files: `11`
-- Tests passing: `67`
+- Tests passing: `69`
 - Coverage:
-  - Statements: `96.32%`
-  - Branches: `78.84%`
+  - Statements: `96.17%`
+  - Branches: `81.97%`
   - Functions: `100%`
-  - Lines: `97.8%`
+  - Lines: `97.74%`
 - Known residual branch gaps are concentrated in defensive renderer branches that are difficult to reach without brittle synthetic mocks.
 
 ## Implementation & Best Practices

--- a/.kilocode/rules/memory-bank/tests-plans.md
+++ b/.kilocode/rules/memory-bank/tests-plans.md
@@ -32,7 +32,7 @@ Brief summary: This file contains separated plans for unit testing each core mod
 - Tests:
   1. Helper functions: `getLifeStageKey` boundary checks; `calculateAgeAtDate` date cases.
   2. renderAgeGrid: enforce max 53 weeks when `eachWeekOfInterval` returns 54 (edge test exists).
-  3. renderCalendarGrid: out-of-bounds weeks, ISO week counts (52/53), present/past/future classification.
+  3. renderCalendarGrid: native UTC ISO boundaries for known 52/53-week years, unique Monday starts, fractional lifespan endpoints, out-of-bounds weeks, and present/past/future classification.
   4. renderMonthsGrid: 12 months per row; month state classification and life stage assignment.
   5. renderYearsGrid: decade rows (10 per row); current year highlighting; state classes.
   6. Failure modes: missing `dateFns` -> renderer writes error message; missing DOM element param.
@@ -44,12 +44,12 @@ Brief summary: This file contains separated plans for unit testing each core mod
 - Primary file: [`js/ui.js`](js/ui.js:1)
 - Priority: Medium
 - Tests:
-  1. areInputsValid / updateButtonState: enabling/disabling logic.
+  1. areInputsValid / updateButtonState: enabling/disabling logic, yesterday maximum, and today/future rejection.
   2. handleCalculation: success path (mock calculator + data), results rendering, progressive reveal.
   3. handleCalculation: error paths (invalid date input, future date, getRemainingExpectancy returns null).
   4. renderCurrentView: clears content when no data; sets aria-label/tabindex when rendered.
   5. handleViewChange: updates `currentView`, toggles `.active` and ARIA attributes, re-renders.
-  6. handleStartOver: resets inputs, hides containers, clears lastCalcData.
+  6. handleStartOver: clears inputs/results/data, restores Weeks (Age) and synchronized tab ARIA state, and focuses birthdate.
 - Test notes: Create DOM fixtures, mock `calculateCurrentAge` and `getRemainingExpectancy` via vi.mock or spies; use time freezing where needed.
 - Estimated effort: 8–12 tests
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ This collaborative approach enabled the creation of this MVP, serving as both a 
   * Renders lifespan as a responsive grid of blocks.
   * Multiple Views:
     * Weeks (arranged by Age Year)
-    * Weeks (arranged by Calendar Year - handles 52/53 week variations)
+    * Weeks (arranged by ISO Calendar Year with timezone-independent 52/53-week handling)
     * Months (arranged by Age Year)
     * Years (arranged by Decade)
   * **Axis Labels:** Dynamically populated top and left axis labels (e.g., Week Number/Month Name/Decade for the top axis, Age Year/Calendar Year for the left axis) provide clear context for each grid view.
   * **Color-Coding:** Blocks are colored to distinguish past, present, future, and general life stages.
 * **User Interface:**
   * Simple and focused input form.
+  * Immediate birthdate validation prevents today or future dates from enabling calculation.
   * **Progressive Reveal:** Results and visualization appear only after calculation.
   * **Integrated Controls & Guide:**
     * View switcher buttons are integrated within a sticky header directly above the grid, remaining visible during scroll.
@@ -54,7 +55,7 @@ This collaborative approach enabled the creation of this MVP, serving as both a 
     * Focusable grid container with descriptive ARIA labels for screen reader compatibility.
   * Responsive design for desktop, tablet, and mobile.
   * Clear disclaimer about the nature of the estimates.
-  * "Start Over" functionality to reset the application.
+  * "Start Over" functionality clears calculation state and restores the default Weeks (Age) view.
 
 ## MVP Status
 
@@ -77,7 +78,7 @@ This collaborative approach enabled the creation of this MVP, serving as both a 
 ## Technology Stack
 
 * **Frontend:** HTML5, CSS3 (including Flexbox, CSS Variables, `calc()`, `aspect-ratio`), Vanilla JavaScript (ES6+ Modules)
-* **Core Dependencies:** `date-fns` v4.1.0 and `date-fns-tz` v1.3.7 (both loaded via CDN) for UTC-safe date calculations and timezone-aware formatting. These libraries are used under the MIT License.
+* **Core Dependencies:** `date-fns` v4.1.0 and optional `date-fns-tz` v1.3.7 are loaded via CDN. Calendar ISO calculations use native UTC helpers; other renderers continue to use `date-fns`. These libraries are used under the MIT License.
 * **Dev Tooling:** Vitest, JSDOM, c8, ESLint (flat config), and TypeScript (`tsc --noEmit` for project typecheck gate).
 * **Development:** Requires a simple local HTTP server (due to ES Modules). No build process currently.
 
@@ -146,6 +147,7 @@ The following are ideas considered out of scope for the MVP but could be explore
 * Internationalization (i18n).
 * Implementing a build process/bundling.
 * Further accessibility enhancements (e.g., advanced color contrast adjustments, visual aids for complex views).
+* A Calendar/Birthday week-alignment toggle for Weeks (Age), tracked in [issue #31](https://github.com/jordanhom/life-visualized/issues/31).
 
 ## Contributing
 

--- a/docs/2026-07-27-changes.md
+++ b/docs/2026-07-27-changes.md
@@ -1,0 +1,38 @@
+# Changes — 2026-07-27
+
+Summary:
+
+- Completed a browser behavior audit covering input validation, view switching, reset state, accessibility focus, and timezone-sensitive rendering.
+- Added immediate birthdate validation:
+  - Set the date input maximum to yesterday using the user's local calendar date.
+  - Keep Calculate disabled for today, future dates, malformed dates, and incomplete forms.
+  - Retain submit-time validation as a defensive check.
+- Expanded Start Over into a complete initial-state reset:
+  - Clear inputs, results, error styling, calculation data, and rendered grid content.
+  - Restore Weeks (Age) as the selected view.
+  - Synchronize tab `aria-selected`, `tabindex`, and tabpanel `aria-labelledby`.
+  - Return focus to the birthdate input.
+- Fixed Weeks (Calendar) timezone behavior:
+  - Replaced local-time `date-fns` ISO calculations with deterministic native UTC helpers.
+  - Render exactly 52 or 53 unique Monday-aligned weeks for each ISO week-year.
+  - Preserve fractional lifespan endpoints through UTC month arithmetic.
+  - Format `Starts UTC` titles directly from UTC date components.
+- Added regression coverage for:
+  - Immediate today/future birthdate rejection.
+  - Complete Start Over view and ARIA reset.
+  - Known 52/53-week ISO years: 2015, 2016, 2020, 2021, 2025, and 2026.
+  - Unique Calendar week titles and fractional lifespan endpoints.
+- Created GitHub issues:
+  - #31 Add week-alignment toggle for age-based visualization.
+  - #32 Fix incorrect ISO week counts and dates in Calendar view.
+
+Notes:
+
+- Calendar weeks remain the default alignment.
+- Issue #31 tracks a future toggle between Calendar and Birthday-aligned weeks.
+- Issue #32 is fixed locally and should remain open until the change reaches `main`.
+- `date-fns-tz` did not expose its expected browser global during the audit; Calendar view no longer depends on it.
+- Month and Year renderers still require a follow-up review of local-time `date-fns` operations.
+- Local validation completed in the conda development environment:
+  - `npm run verify`: 11 test files, 69 tests passing.
+  - `npm run test:coverage`: 96.17% statements, 81.97% branches, 100% functions, 97.74% lines.

--- a/docs/gridRenderer.md
+++ b/docs/gridRenderer.md
@@ -18,7 +18,8 @@ Public API
 
 Key internal concepts
 - LIFE_STAGES array and getLifeStageKey(age)
-- UTC-normalized date handling; relies on global `dateFns` v4.x
+- UTC-normalized date handling; Calendar ISO boundaries use native UTC helpers while other views rely on global `dateFns` v4.x
+- `startOfISOWeekUTC`, `getISOWeekYearUTC`, `getISOWeekStartUTC`, and `getISOWeeksInYearUTC`
 - DocumentFragment usage for performance
 - Week-generation logic for ISO weeks with handling for 52/53 week years and edge cases near birthdays
 
@@ -33,7 +34,8 @@ Behavioral details & edge cases
   - Titles include week start date and indication of current week.
 - Weeks-by-Calendar:
   - Iterates ISO years between birth and estimated end.
-  - Uses getISOWeeksInYear to render either 52 or 53 weeks per row.
+  - Calculates ISO week-year boundaries directly from UTC date components to render exactly 52 or 53 unique weeks per row, independent of the browser timezone.
+  - Preserves fractional lifespan estimates through UTC month arithmetic and formats `Starts UTC` titles from UTC components.
   - Marks blocks outside lifespan as `out-of-bounds`.
 - Months:
   - Renders up to ceil(totalYears * 12) month blocks grouped in 12-per-row.
@@ -57,7 +59,7 @@ Refactor considerations
 
 Testing guidance
 - Create `tests/grid-renderer-smoke.html` that imports the module and calls each renderer with deterministic inputs.
-- Validate block counts and titles to ensure no regressions during refactor.
+- Validate known 52/53-week ISO years, unique block titles, UTC Monday starts, and fractional lifespan endpoints.
 
 Performance notes
 - Already uses DocumentFragment; maintain this.

--- a/docs/memory-bank.md
+++ b/docs/memory-bank.md
@@ -1,5 +1,25 @@
 # Memory Bank
 
+## 2026-07-27
+
+- Behavior audit created GitHub issues:
+  - https://github.com/jordanhom/life-visualized/issues/31
+  - https://github.com/jordanhom/life-visualized/issues/32
+- Implemented UI refinements:
+  - Birthdate input is limited to yesterday and Calculate remains disabled for today/future dates.
+  - Start Over clears all calculation/UI state and restores Weeks (Age) with synchronized tab ARIA state.
+- Fixed Calendar visualization timezone behavior:
+  - Replaced local-time ISO week calculations with native UTC helpers.
+  - Verified known 52/53-week years and UTC Monday start dates in the Pacific-time browser runtime.
+  - Preserved fractional lifespan endpoints and UTC title formatting.
+- Added regression tests:
+  - `tests/unit/ui.test.js`
+  - `tests/unit/gridRenderer.calendar.test.js`
+- Verification:
+  - `npm run verify` passes.
+  - Baseline: 11 test files, 69 tests passing.
+  - Coverage: 96.17% statements, 81.97% branches, 100% functions, 97.74% lines.
+
 ## 2026-03-25
 
 - Manual review identified two gaps and tracked them as GitHub issues:

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -10,14 +10,18 @@ Public API
 - setupEventListeners()
 
 Key responsibilities
-- Normalize birth date to UTC midnight before passing to calculators/renderers.
+- Set the birthdate maximum to yesterday in the user's local calendar and reject today/future dates immediately.
+- Normalize accepted birth dates to UTC midnight before passing them to calculators/renderers.
 - Maintain runtime state: `currentView` and `lastCalcData`.
 - Enable/disable Calculate button and present loading/error states.
-- Show/hide UI sections (form, results, grid container, Start Over).
+- Show/hide UI sections and fully restore initial state on Start Over.
 - Wire view switcher tablist keyboard behavior and ARIA updates.
 
 Important internal functions (testable)
 - areInputsValid()
+- getTodayUTC()
+- formatDateInputValue(date)
+- parseBirthdateUTC(value)
 - updateButtonState()
 - updateAxisLabels(show, topText, leftText)
 - renderCurrentView()
@@ -44,10 +48,13 @@ Integration points
 Testing guidance
 - Unit-ish browser harness: simulate form input and submit, assert `#results-area` text and that `#grid-content-area` has children.
 - ARIA/focus tests: ensure view switcher buttons update `aria-selected`, `tabindex`, and `aria-labelledby` on `#grid-content-area`.
+- Validation tests: freeze time, assert `#birthdate.max` is yesterday, and ensure today/future dates leave Calculate disabled.
+- Reset tests: switch away from Weeks (Age), then assert Start Over clears results/data and restores the default tab and focus state.
 - Deterministic tests: allow injecting a fake "now" into helper functions where feasible for repeatable assertions.
 
 Notes & refactor constraints
 - Keep UTC normalization behavior identical when refactoring.
+- Treat user-facing "today" as the browser's local calendar date before converting accepted date-only values to UTC.
 - When moving logic into utils, preserve CSS class names (`stage-*`, `present`, `past`, `future`, `out-of-bounds`) and titles to avoid stylesheet/UX regressions.
 - Progressive reveal and focus management are UX-sensitive—test Safari (known tabbing quirks).
 

--- a/js/gridRenderer.js
+++ b/js/gridRenderer.js
@@ -37,6 +37,47 @@ function toUTCStartOfDay(date) {
     return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
 }
 
+function addYearsUTC(date, years) {
+    const targetMonthIndex = date.getUTCMonth() + Math.trunc(years * 12);
+    const targetYear = date.getUTCFullYear() + Math.floor(targetMonthIndex / 12);
+    const targetMonth = ((targetMonthIndex % 12) + 12) % 12;
+    const lastDayOfTargetMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+    return new Date(Date.UTC(
+        targetYear,
+        targetMonth,
+        Math.min(date.getUTCDate(), lastDayOfTargetMonth)
+    ));
+}
+
+function startOfISOWeekUTC(date) {
+    const weekStart = toUTCStartOfDay(date);
+    const daysSinceMonday = (weekStart.getUTCDay() + 6) % 7;
+    weekStart.setUTCDate(weekStart.getUTCDate() - daysSinceMonday);
+    return weekStart;
+}
+
+function getISOWeekYearUTC(date) {
+    const thursday = startOfISOWeekUTC(date);
+    thursday.setUTCDate(thursday.getUTCDate() + 3);
+    return thursday.getUTCFullYear();
+}
+
+function getISOWeekStartUTC(isoYear, weekNumber = 1) {
+    const firstWeekStart = startOfISOWeekUTC(new Date(Date.UTC(isoYear, 0, 4)));
+    firstWeekStart.setUTCDate(firstWeekStart.getUTCDate() + ((weekNumber - 1) * 7));
+    return firstWeekStart;
+}
+
+function getISOWeeksInYearUTC(isoYear) {
+    const currentYearStart = getISOWeekStartUTC(isoYear);
+    const nextYearStart = getISOWeekStartUTC(isoYear + 1);
+    return Math.round((nextYearStart - currentYearStart) / (7 * 24 * 60 * 60 * 1000));
+}
+
+function formatUTCDate(date) {
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')}`;
+}
+
 // Helper: Get stage key based on age. (Used for styling blocks)
 function getLifeStageKey(age) {
     for (const stage of LIFE_STAGES) {
@@ -228,14 +269,13 @@ function renderCalendarGrid(inputBirthDate, totalLifespanYearsEst, gridContentAr
         // --- Date Setup (UTC) ---
         const birthDateUTC = inputBirthDate; // Already normalized by ui.js
         const nowUTC = toUTCStartOfDay(new Date());
-        const estimatedEndDateRough = dateFns.addYears(birthDateUTC, totalLifespanYearsEst);
-        const estimatedEndDateUTC = toUTCStartOfDay(estimatedEndDateRough);
-        const startISOYear = dateFns.getISOWeekYear(birthDateUTC);
-        const endISOYear = dateFns.getISOWeekYear(estimatedEndDateUTC);
+        const estimatedEndDateUTC = addYearsUTC(birthDateUTC, totalLifespanYearsEst);
+        const startISOYear = getISOWeekYearUTC(birthDateUTC);
+        const endISOYear = getISOWeekYearUTC(estimatedEndDateUTC);
         // Determine the start of the ISO week containing the birth date
-        const firstWeekStartDateUTC = dateFns.startOfISOWeek(birthDateUTC);
+        const firstWeekStartDateUTC = startOfISOWeekUTC(birthDateUTC);
         // Determine the start of the current ISO week
-        const currentActualWeekStartDateUTC = dateFns.startOfISOWeek(nowUTC);
+        const currentActualWeekStartDateUTC = startOfISOWeekUTC(nowUTC);
 
         // --- Grid Rendering ---
         gridContentAreaElement.innerHTML = ''; // Clear previous content from the specific area
@@ -250,26 +290,12 @@ function renderCalendarGrid(inputBirthDate, totalLifespanYearsEst, gridContentAr
             yearRow.setAttribute('data-year', isoYear); // Add calendar year data attribute
             yearRow.setAttribute('aria-label', `Calendar Year ${isoYear}`); // Add row label
 
-            // Use a date within the target ISO year to get context for week calculations
-            const dateForYearContext = new Date(Date.UTC(isoYear, 0, 4));
             // Determine number of ISO weeks in this specific calendar year (can be 52 or 53)
-            const weeksInThisYear = dateFns.getISOWeeksInYear(dateForYearContext);
+            const weeksInThisYear = getISOWeeksInYearUTC(isoYear);
 
             // Loop through each week number within the ISO year
             for (let weekNum = 1; weekNum <= weeksInThisYear; weekNum++) {
-                let currentRenderWeekStartDateUTC;
-                try {
-                    // Calculate the start date of the specific ISO week/year
-                    let tempDate = dateFns.setISOWeekYear(dateForYearContext, isoYear);
-                    tempDate = dateFns.setISOWeek(tempDate, weekNum);
-                    currentRenderWeekStartDateUTC = dateFns.startOfISOWeek(tempDate);
-                } catch (e) {
-                    // Handle potential errors if date-fns calculation fails (unlikely)
-                    console.error(`Error calculating start of week ${weekNum}, year ${isoYear}:`, e);
-                    currentRenderWeekStartDateUTC = null;
-                }
-
-                if (!currentRenderWeekStartDateUTC) continue; // Skip if calculation failed
+                const currentRenderWeekStartDateUTC = getISOWeekStartUTC(isoYear, weekNum);
 
                 const weekBlock = document.createElement('div');
                 weekBlock.classList.add('week-block');
@@ -280,9 +306,7 @@ function renderCalendarGrid(inputBirthDate, totalLifespanYearsEst, gridContentAr
                 weekBlock.classList.add(`stage-${stageKey}`);
 
                 let stateClass = '';
-                let formattedStart = (typeof dateFnsTz !== 'undefined' && dateFnsTz.formatInTimeZone)
-                    ? dateFnsTz.formatInTimeZone(currentRenderWeekStartDateUTC, 'UTC', 'yyyy-MM-dd')
-                    : dateFns.format(currentRenderWeekStartDateUTC, 'yyyy-MM-dd');
+                const formattedStart = formatUTCDate(currentRenderWeekStartDateUTC);
                 let title = `Year ${isoYear}, Week ${weekNum} (Starts UTC: ${formattedStart})`;
 
                 // Check Out of Bounds: Is this week before the first week containing birth OR after estimated end?

--- a/js/ui.js
+++ b/js/ui.js
@@ -37,8 +37,9 @@ let gridContentWrapper = null; // Wrapper for left label + content area
 
 
 // --- State Variables ---
+const DEFAULT_VIEW = 'weeks-age';
 // Tracks the currently selected grid view type
-let currentView = 'weeks-age'; // Default view ('weeks-age', 'weeks-calendar', 'months', or 'years') - Matches HTML default button data-view
+let currentView = DEFAULT_VIEW; // Matches the default button in index.html
 // Stores results of the last calculation to allow re-rendering on view change without recalculating
 let lastCalcData = {
     birthDate: null, // Stores the UTC-normalized birthDate object
@@ -50,10 +51,38 @@ let lastCalcData = {
  * @returns {boolean} True if inputs are valid, false otherwise.
  */
 function areInputsValid() {
-    // Ensure elements exist before accessing their properties
-    const birthdateFilled = birthdateInput && birthdateInput.value !== '';
+    const birthDateUTC = parseBirthdateUTC(birthdateInput?.value);
     const sexSelected = sexInput && sexInput.value !== ''; // "Select..." option has value=""
-    return birthdateFilled && sexSelected;
+    return Boolean(birthDateUTC && birthDateUTC < getTodayUTC() && sexSelected);
+}
+
+function getTodayUTC() {
+    const now = new Date();
+    // Represent the user's local calendar date at UTC midnight for date-only comparisons.
+    return new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+}
+
+function formatDateInputValue(date) {
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')}`;
+}
+
+function parseBirthdateUTC(value) {
+    if (!value) return null;
+
+    const [yearStr, monthStr, dayStr] = value.split('-');
+    const year = Number(yearStr);
+    const monthIndex = Number(monthStr) - 1;
+    const day = Number(dayStr);
+    const birthDateUTC = new Date(Date.UTC(year, monthIndex, day));
+
+    if (Number.isNaN(birthDateUTC.getTime()) ||
+        birthDateUTC.getUTCFullYear() !== year ||
+        birthDateUTC.getUTCMonth() !== monthIndex ||
+        birthDateUTC.getUTCDate() !== day) {
+        return null;
+    }
+
+    return birthDateUTC;
 }
 
 /**
@@ -63,9 +92,14 @@ function areInputsValid() {
 function updateButtonState() {
     if (!calculateBtn) return; // Guard clause if button not found
 
-    const isValid = areInputsValid();
+    const inputsFilled = Boolean(birthdateInput?.value && sexInput?.value);
+    const isValid = inputsFilled && areInputsValid();
     calculateBtn.disabled = !isValid;
-    calculateBtn.title = isValid ? '' : 'Please fill in both fields.';
+    calculateBtn.title = isValid
+        ? ''
+        : inputsFilled
+            ? 'Please enter a valid birth date in the past.'
+            : 'Please fill in both fields.';
 }
 
 /**
@@ -239,22 +273,10 @@ async function handleCalculation(event) {
         return; // Exit, leaving only results area visible
     }
 
-    // Create Date object from input string deterministically in UTC.
-    const [yearStr, monthStr, dayStr] = birthdateStr.split('-');
-    const year = Number(yearStr);
-    const monthIndex = Number(monthStr) - 1;
-    const day = Number(dayStr);
-    const birthDateUTC = new Date(Date.UTC(year, monthIndex, day));
-
-    const now = new Date();
-    const todayUTC = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-    const isValidBirthDate = !Number.isNaN(birthDateUTC.getTime()) &&
-        birthDateUTC.getUTCFullYear() === year &&
-        birthDateUTC.getUTCMonth() === monthIndex &&
-        birthDateUTC.getUTCDate() === day;
+    const birthDateUTC = parseBirthdateUTC(birthdateStr);
 
     // Check validity and ensure date is in the past.
-    if (!isValidBirthDate || birthDateUTC >= todayUTC) {
+    if (!birthDateUTC || birthDateUTC >= getTodayUTC()) {
         displayError('Please enter a valid birth date in the past (YYYY-MM-DD).');
         renderCurrentView(); // Clear grid content area if validation fails
         finalizeCalculation();
@@ -288,10 +310,9 @@ async function handleCalculation(event) {
         gridContainer.classList.remove('hidden');
         // gridControlsHeader and gridGuideDetails become visible when gridContainer does.
 
-        // Set focus to the first view switcher button after successful calculation
-        if (viewSwitcherButtons && viewSwitcherButtons.length > 0) {
-            viewSwitcherButtons[0].focus();
-        }
+        const activeViewButton = Array.from(viewSwitcherButtons)
+            .find(button => button.dataset.view === currentView);
+        activeViewButton?.focus();
 
     } catch (error) {
         // --- Handle Errors from Calculation or Rendering ---
@@ -387,6 +408,8 @@ function handleStartOver() {
 
     // Hide results, grid, and the start over button itself
     resultsArea.classList.add('hidden');
+    resultsArea.classList.remove('error-message');
+    resultsArea.innerHTML = '';
     gridContainer.classList.add('hidden');
     updateAxisLabels(false); // Hide axis labels
     // gridControlsHeader and gridGuideDetails are hidden along with gridContainer
@@ -399,6 +422,17 @@ function handleStartOver() {
     // Reset stored calculation data
     lastCalcData.birthDate = null;
     lastCalcData.totalLifespanYearsEst = null;
+
+    currentView = DEFAULT_VIEW;
+    viewSwitcherButtons.forEach(button => {
+        const isDefault = button.dataset.view === DEFAULT_VIEW;
+        button.classList.toggle('active', isDefault);
+        button.setAttribute('aria-selected', isDefault.toString());
+        button.setAttribute('tabindex', isDefault ? '0' : '-1');
+        if (isDefault && gridContentArea) {
+            gridContentArea.setAttribute('aria-labelledby', button.id);
+        }
+    });
 
     updateButtonState(); // Disable calculate button
     if (birthdateInput) birthdateInput.focus(); // Focus on the first input field
@@ -489,6 +523,9 @@ function setupEventListeners() {
 
     // Add event listeners to form inputs to update button state
     if (birthdateInput) {
+        const yesterdayUTC = getTodayUTC();
+        yesterdayUTC.setUTCDate(yesterdayUTC.getUTCDate() - 1);
+        birthdateInput.max = formatDateInputValue(yesterdayUTC);
         birthdateInput.addEventListener('input', updateButtonState);
     } else {
         console.error("Birthdate input element (#birthdate) not found.");

--- a/tests/unit/gridRenderer.calendar.test.js
+++ b/tests/unit/gridRenderer.calendar.test.js
@@ -85,60 +85,37 @@ describe('gridRenderer calendar view', () => {
     expect(someWeek.title).toContain('Year');
   });
 
-  it('handles 53-week ISO years by capping week rows to at most 53 blocks', async () => {
-    // Recreate environment with a mock that reports 53 weeks in a year
-    vi.resetModules();
-    const { JSDOM } = await import('jsdom');
-    const dom = new JSDOM('<!doctype html><html><body></body></html>');
-    global.window = dom.window;
-    global.document = dom.window.document;
-    global.HTMLElement = dom.window.HTMLElement;
-    global.Node = dom.window.Node;
-
-    // date-fns mock with 53 weeks in year
-    global.dateFns = {
-      startOfDay: (d) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())),
-      startOfISOWeek: (d) => {
-        const dt = new Date(d);
-        const day = dt.getUTCDay();
-        const diff = (day === 0 ? -6 : 1) - day;
-        return new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth(), dt.getUTCDate() + diff));
-      },
-      addYears: (d, n) => new Date(Date.UTC(d.getUTCFullYear() + n, d.getUTCMonth(), d.getUTCDate())),
-      getISOWeekYear: (d) => new Date(d).getUTCFullYear(),
-      getISOWeeksInYear: (_d) => 53,
-      setISOWeekYear: (date, isoYear) => new Date(Date.UTC(isoYear, 0, 4)),
-      setISOWeek: (date, weekNum) => {
-        const firstWeekMonday = new Date(Date.UTC(date.getUTCFullYear(), 0, 4));
-        return new Date(firstWeekMonday.getTime() + (weekNum - 1) * 7 * 24 * 60 * 60 * 1000);
-      },
-      format: (d) => {
-        const y = d.getUTCFullYear();
-        const m = String(d.getUTCMonth() + 1).padStart(2, '0');
-        const day = String(d.getUTCDate()).padStart(2, '0');
-        return `${y}-${m}-${day}`;
-      },
-      isBefore: (a, b) => a.getTime() < b.getTime(),
-      isAfter: (a, b) => a.getTime() > b.getTime(),
-    };
-
+  it('calculates known 52 and 53 week ISO years from UTC boundaries', async () => {
     const { renderCalendarGrid } = await import('../../js/gridRenderer.js');
-
-    const birthDateUTC = new Date(Date.UTC(1970, 0, 1));
-    const totalYears = 1;
     const container = document.createElement('div');
 
-    renderCalendarGrid(birthDateUTC, totalYears, container);
+    renderCalendarGrid(new Date(Date.UTC(2014, 0, 1)), 14, container);
 
-    const rows = container.querySelectorAll('.year-row');
-    expect(rows.length).toBeGreaterThan(0);
+    const expectedYears = [
+      { year: 2015, count: 53, firstStart: '2014-12-29' },
+      { year: 2016, count: 52, firstStart: '2016-01-04' },
+      { year: 2020, count: 53, firstStart: '2019-12-30' },
+      { year: 2021, count: 52, firstStart: '2021-01-04' },
+      { year: 2025, count: 52, firstStart: '2024-12-30' },
+      { year: 2026, count: 53, firstStart: '2025-12-29' },
+    ];
 
-    // For each year row, ensure we don't render more than 53 .week-block elements
-    rows.forEach((row) => {
-      const weekBlocks = row.querySelectorAll('.week-block');
-      // The renderer should cap to 53 even when date-fns reports 53 weeks
-      expect(weekBlocks.length).toBeLessThanOrEqual(53);
+    expectedYears.forEach(({ year, count, firstStart }) => {
+      const row = container.querySelector(`[data-year="${year}"]`);
+      const weekBlocks = [...row.querySelectorAll('.week-block')];
+      expect(weekBlocks).toHaveLength(count);
+      expect(weekBlocks[0].title).toContain(`Starts UTC: ${firstStart}`);
+      expect(new Set(weekBlocks.map((block) => block.title)).size).toBe(count);
     });
+  });
+
+  it('preserves fractional lifespan years when determining the final ISO year', async () => {
+    const { renderCalendarGrid } = await import('../../js/gridRenderer.js');
+    const container = document.createElement('div');
+
+    renderCalendarGrid(new Date(Date.UTC(2020, 0, 1)), 1.5, container);
+
+    expect(container.querySelector('[data-year="2021"]')).not.toBeNull();
   });
 
   it('does not throw and renders rows spanning ISO year boundaries (Dec 31 births)', async () => {
@@ -249,52 +226,4 @@ describe('gridRenderer calendar view', () => {
     vi.useRealTimers();
   });
 
-  it('continues rendering when one ISO week calculation throws', async () => {
-    vi.resetModules();
-    const { JSDOM } = await import('jsdom');
-    const dom = new JSDOM('<!doctype html><html><body></body></html>');
-    global.window = dom.window;
-    global.document = dom.window.document;
-    global.HTMLElement = dom.window.HTMLElement;
-    global.Node = dom.window.Node;
-
-    global.dateFns = {
-      startOfDay: (d) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())),
-      startOfISOWeek: (d) => {
-        const dt = new Date(d);
-        const day = dt.getUTCDay();
-        const diff = (day === 0 ? -6 : 1) - day;
-        return new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth(), dt.getUTCDate() + diff));
-      },
-      addYears: (d, n) => new Date(Date.UTC(d.getUTCFullYear() + n, d.getUTCMonth(), d.getUTCDate())),
-      getISOWeekYear: (d) => new Date(d).getUTCFullYear(),
-      getISOWeeksInYear: () => 3,
-      setISOWeekYear: (_date, isoYear) => new Date(Date.UTC(isoYear, 0, 4)),
-      setISOWeek: (date, weekNum) => {
-        if (weekNum === 2) throw new Error('forced week failure');
-        const firstWeekMonday = new Date(Date.UTC(date.getUTCFullYear(), 0, 6));
-        return new Date(firstWeekMonday.getTime() + (weekNum - 1) * 7 * 24 * 60 * 60 * 1000);
-      },
-      format: (d) => {
-        const y = d.getUTCFullYear();
-        const m = String(d.getUTCMonth() + 1).padStart(2, '0');
-        const day = String(d.getUTCDate()).padStart(2, '0');
-        return `${y}-${m}-${day}`;
-      },
-      isBefore: (a, b) => a.getTime() < b.getTime(),
-      isAfter: (a, b) => a.getTime() > b.getTime(),
-    };
-
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { renderCalendarGrid } = await import('../../js/gridRenderer.js');
-    const container = document.createElement('div');
-
-    renderCalendarGrid(new Date(Date.UTC(2025, 0, 6)), 1, container);
-
-    expect(errSpy).toHaveBeenCalled();
-    expect(errSpy.mock.calls.some(([msg]) => String(msg).includes('Error calculating start of week'))).toBe(true);
-    expect(container.querySelector('.error-message')).toBeNull();
-    expect(container.querySelectorAll('.week-block').length).toBeGreaterThan(0);
-    expect(container.querySelectorAll('.week-block').length).toBeLessThan(6);
-  });
 });

--- a/tests/unit/ui.test.js
+++ b/tests/unit/ui.test.js
@@ -136,6 +136,36 @@ describe('ui module (setup & form flow)', () => {
     expect(calculateBtn.disabled).toBe(true);
   });
 
+  it('sets the latest birthdate and disables calculation for today or future dates', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-27T12:00:00Z'));
+
+    const { setupEventListeners } = await import('../../js/ui.js');
+    setupEventListeners();
+
+    const birthdateInput = document.getElementById('birthdate');
+    const sexSelect = document.getElementById('sex');
+    const calculateBtn = document.getElementById('calculate-btn');
+
+    expect(birthdateInput.max).toBe('2026-07-26');
+
+    sexSelect.value = 'male';
+    sexSelect.dispatchEvent(new global.Event('change', { bubbles: true }));
+
+    birthdateInput.value = '2026-07-27';
+    birthdateInput.dispatchEvent(new global.Event('input', { bubbles: true }));
+    expect(calculateBtn.disabled).toBe(true);
+    expect(calculateBtn.title).toBe('Please enter a valid birth date in the past.');
+
+    birthdateInput.value = '2026-07-28';
+    birthdateInput.dispatchEvent(new global.Event('input', { bubbles: true }));
+    expect(calculateBtn.disabled).toBe(true);
+
+    birthdateInput.value = '2026-07-26';
+    birthdateInput.dispatchEvent(new global.Event('input', { bubbles: true }));
+    expect(calculateBtn.disabled).toBe(false);
+  });
+
   it('handleCalculation success path displays results, hides form, and reveals grid', async () => {
     const { setupEventListeners } = await import('../../js/ui.js');
 
@@ -268,6 +298,14 @@ describe('ui module (setup & form flow)', () => {
   });
 
   it('Start Over button resets the UI to initial state after success', async () => {
+    const viewSwitcher = document.getElementById('view-switcher');
+    const yearsButton = document.createElement('button');
+    yearsButton.className = 'view-button';
+    yearsButton.id = 'view-years';
+    yearsButton.setAttribute('role', 'tab');
+    yearsButton.dataset.view = 'years';
+    viewSwitcher.appendChild(yearsButton);
+
     const { setupEventListeners } = await import('../../js/ui.js');
 
     setupEventListeners();
@@ -279,6 +317,8 @@ describe('ui module (setup & form flow)', () => {
     const gridContainer = document.getElementById('life-grid-container');
     const startOverContainer = document.getElementById('start-over-container');
     const startOverBtn = document.getElementById('start-over-btn');
+    const defaultViewButton = document.getElementById('view-weeks-age');
+    const gridContentArea = document.getElementById('grid-content-area');
 
     // Fill inputs to allow a successful calculation (calculator mock returns values in beforeEach)
     birthdateInput.value = '1990-01-01';
@@ -296,6 +336,9 @@ describe('ui module (setup & form flow)', () => {
     expect(gridContainer.classList.contains('hidden')).toBe(false);
     expect(startOverContainer.classList.contains('hidden')).toBe(false);
 
+    yearsButton.dispatchEvent(new global.MouseEvent('click', { bubbles: true }));
+    expect(yearsButton.getAttribute('aria-selected')).toBe('true');
+
     // Click start over
     startOverBtn.dispatchEvent(new global.MouseEvent('click', { bubbles: true }));
 
@@ -308,6 +351,14 @@ describe('ui module (setup & form flow)', () => {
     expect(gridContainer.classList.contains('hidden')).toBe(true);
     expect(birthdateInput.value).toBe('');
     expect(sexSelect.value).toBe('');
+    expect(resultsArea.innerHTML).toBe('');
+    expect(defaultViewButton.classList.contains('active')).toBe(true);
+    expect(defaultViewButton.getAttribute('aria-selected')).toBe('true');
+    expect(defaultViewButton.getAttribute('tabindex')).toBe('0');
+    expect(yearsButton.classList.contains('active')).toBe(false);
+    expect(yearsButton.getAttribute('aria-selected')).toBe('false');
+    expect(yearsButton.getAttribute('tabindex')).toBe('-1');
+    expect(gridContentArea.getAttribute('aria-labelledby')).toBe(defaultViewButton.id);
   });
 
   it('keyboard navigation on view switcher changes active view and ARIA attributes', async () => {


### PR DESCRIPTION
## Summary
- calculate Calendar view ISO week boundaries and 52/53-week years deterministically in UTC
- validate birthdates immediately and disable calculation for invalid, current, or future dates
- make Start Over fully reset calculation state, selected view, accessibility state, and focus
- expand unit coverage and update project documentation and memory-bank records

## Root cause
Calendar generation mixed UTC date-only values with local-time date-fns operations. In timezones west of UTC, that could shift boundaries into the previous calendar day and produce incorrect ISO week counts or labels. Form validation and reset behavior also did not consistently restore the documented initial state.

## Impact
Calendar week counts and titles are now stable across browser timezones. Invalid birthdates are rejected before submission, and Start Over returns the interface to the default Weeks (Age) state.

## Validation
- `conda run -n base npm run verify`
- `conda run -n base npm run test:coverage`
- 11 test files and 69 tests passed
- 96.17% statements, 81.97% branches, 100% functions, 97.74% lines

Fixes #32