### PR TITLE
Fix Month and Year timezone drift

### DIFF
--- a/.kilocode/rules/memory-bank/activeContext.md
+++ b/.kilocode/rules/memory-bank/activeContext.md
@@ -1,37 +1,37 @@
 # Active Context — Life Visualized
 
 ## Last Update
-- Date: 2026-07-27
-- Summary: Behavior audit refinements completed for input validation, Start Over state, and timezone-independent ISO Calendar weeks.
+- Date: 2026-07-28
+- Summary: Month and Year renderers now use timezone-independent UTC boundaries, titles, and state classification.
 
 ## Recent Changes
-- Added immediate birthdate validation:
-  - `#birthdate.max` is set to yesterday using the browser's local calendar date.
-  - Today, future dates, malformed dates, and incomplete forms keep Calculate disabled.
-  - Submit-time validation remains as a defensive check.
-- Expanded Start Over into a complete initial-state reset:
-  - Clears inputs, results, calculation data, grid content, and error styling.
-  - Restores Weeks (Age) as the active view with synchronized `aria-selected`, `tabindex`, and `aria-labelledby`.
-  - Successful calculations focus the selected tab instead of always focusing the first tab.
-- Replaced Calendar view's local-time `date-fns` ISO calculations with deterministic UTC helpers:
-  - Correct 52/53-week counts and Monday week starts across browser timezones.
-  - UTC-safe title formatting no longer depends on `date-fns-tz`.
-  - Fractional lifespan endpoints are retained using month-based UTC arithmetic.
-- Added regression coverage in:
-  - `tests/unit/ui.test.js`
-  - `tests/unit/gridRenderer.calendar.test.js`
-- Created GitHub tracking:
-  - Issue #31: Calendar/Birthday week-alignment toggle (backlog enhancement).
-  - Issue #32: Incorrect ISO Calendar week counts/dates (fixed locally; open pending merge).
+- Replaced Month view's local-time `date-fns` operations with native UTC helpers:
+  - Generates exactly `ceil(totalLifespanYearsEst * 12)` month blocks.
+  - Calculates month starts, current-month state, life stages, and `Starts UTC` titles from UTC components.
+  - Produces identical boundaries under UTC, Los Angeles, London, Tokyo, and Auckland timezone settings.
+- Replaced Year view's local-time anniversary operations and formatting:
+  - Generates exactly `ceil(totalLifespanYearsEst)` UTC birthday-anniversary blocks.
+  - Classifies past/present/future from consecutive anniversary boundaries.
+  - Defines February 29 anniversaries as February 28 in non-leap years.
+- Reworked Month/Year tests to poison local-time `dateFns` operations and exercise production UTC helpers.
+- Browser-verified the issue reproductions in the Pacific-time runtime:
+  - Month Age 0/Month 1 for `2000-01-01` starts `2000-01-01`.
+  - Year Age 0 for `1990-06-15` starts `1990-06-15`.
+  - Leap-day titles follow Feb 29 -> Feb 28 -> Feb 29 as years require.
+- GitHub tracking:
+  - Issue #32 is closed after PR #37 reached `main`.
+  - Issues #33 and #34 are fixed locally on `codex/fix-month-year-timezones`, pending merge.
+  - Issue #35 tracks broader worldwide local-time correctness.
 - Current local test baseline: 11 files / 69 tests passing.
 - Current local coverage baseline:
-  - Statements `96.17%`
-  - Branches `81.97%`
+  - Statements `95.81%`
+  - Branches `82.62%`
   - Functions `100%`
-  - Lines `97.74%`
+  - Lines `97.36%`
 
 ## Next Steps
-- Commit and merge the current behavior refinements; close issue #32 after the fix reaches `main`.
+- Commit, open a PR, and merge the Month/Year fixes; close issues #33 and #34 after they reach `main`.
+- Continue worldwide timezone correctness under issue #35, especially Weeks (Age), current-period semantics, and age calculation at local midnight.
 - Implement issue #31 with Calendar weeks as the default alignment.
-- Address remaining timezone-sensitive Month/Year renderer operations and the unavailable `date-fns-tz` runtime global identified during the audit.
+- Decide whether to remove the unavailable `date-fns-tz` runtime dependency.
 - Decide whether to enforce minimum branch coverage in CI.

--- a/.kilocode/rules/memory-bank/architecture.md
+++ b/.kilocode/rules/memory-bank/architecture.md
@@ -19,7 +19,7 @@
 * **Vanilla JavaScript (ES Modules):** Chosen for simplicity and performance, avoiding framework overhead for this specific application scope. Enables clear separation of concerns via modules.
 * **UTC-Based Date Handling:**
   * **Decision:** All internal date storage and calculations are performed using UTC to ensure consistency and avoid timezone/DST errors.
-  * **Pattern:** Input date strings are validated against the user's local calendar date, then normalized to UTC midnight in `ui.js`. Calendar ISO boundaries are calculated with native UTC helpers; other renderers still use global `date-fns` operations.
+  * **Pattern:** Input date strings are validated against the user's local calendar date, then normalized to UTC midnight in `ui.js`. Calendar, Month, and Year boundaries are calculated with native UTC helpers; Weeks (Age) still uses global `date-fns` operations.
 * **UI State Management (`ui.js`):**
   * **Pattern:** Simple module-level variables (`currentView`, `lastCalcData`) are used to maintain the selected view and the results of the last calculation.
   * **Rationale:** Sufficient for the current application state; avoids the complexity of a dedicated state management library. Enables efficient view switching without recalculation.
@@ -68,7 +68,7 @@
     1. `ui.js` (`renderCurrentView`) determines the view type (`currentView`).
     2. `ui.js` calls the appropriate function in `gridRenderer.js` (e.g., `renderMonthsGrid`), passing `lastCalcData` and the specific `#grid-content-area` element. (UPDATED)
     3. `gridRenderer.js` function clears the *provided element's* (`#grid-content-area`) content. (UPDATED)
-    4. `gridRenderer.js` performs date calculations; Calendar view uses native UTC ISO helpers while other views currently use `date-fns`.
+    4. `gridRenderer.js` performs date calculations; Calendar, Month, and Year views use native UTC helpers while Weeks (Age) currently uses `date-fns`.
     5. `gridRenderer.js` generates DOM elements (rows, blocks) with correct classes/attributes.
     6. `gridRenderer.js` appends elements to the *provided element* (`#grid-content-area`). (UPDATED)
     7. `gridRenderer.js` sets the `aria-label` on the *parent* (`#life-grid-container`) for overall context. (UPDATED)
@@ -82,6 +82,8 @@
 
 * **`gridRenderer.js` - Age View Week Logic:** Uses `eachWeekOfInterval` + `filter(isBefore)` + `.pop()` (if length 54) to accurately determine the ISO weeks starting within each year of life, ensuring visual consistency (max 53 weeks/row).
 * **`gridRenderer.js` - Calendar View:** Calculates ISO week-year boundaries directly from UTC date components and correctly handles the 52/53 week variation without browser-timezone drift. Applies `out-of-bounds` styling based on comparison with `firstWeekStartDateUTC` and `estimatedEndDateUTC`.
+* **`gridRenderer.js` - Month View:** Generates exactly `ceil(totalYears * 12)` UTC month starts, classifies the current UTC month, and derives stages and titles from corrected UTC boundaries.
+* **`gridRenderer.js` - Year View:** Generates exactly `ceil(totalYears)` UTC birthday anniversaries and classifies state by anniversary intervals. February 29 anniversaries clamp to February 28 in non-leap years.
 * **CSS `calc()` + `aspect-ratio`:** The core mechanism for ensuring Month/Year blocks fill the fixed container width while remaining square. Formulas must be updated in media queries if gaps change.
 * **`js/ui.js` - `handleViewChange()`:** Logic handles clicks on `.view-button` elements, reads `data-view`, and manages `.active`, `aria-selected`, `tabindex`, and tabpanel `aria-labelledby` attributes.
 * **`index.html` - `#grid-content-area`:** A dedicated `div` within `#life-grid-container` that serves as the specific target for grid rendering, preventing clearing of other nested elements like the header and guide. (NEW)

--- a/.kilocode/rules/memory-bank/context.md
+++ b/.kilocode/rules/memory-bank/context.md
@@ -4,23 +4,27 @@
 Keep all visualization and UI state behavior deterministic across browser timezones while maintaining a high-signal test baseline.
 
 ## Current Task
-Document and prepare the audited behavior refinements for commit and review.
+Fix issues #33 and #34 by making Month and Year rendering independent of browser timezone.
 
 ## Recent Changes
 
 - Added immediate birthdate validation and a local-calendar `max` of yesterday.
 - Start Over now restores the complete initial state, including Weeks (Age) selection and ARIA state.
 - Calendar view now computes ISO week years, week starts, and 52/53-week counts directly in UTC.
-- Added deterministic regression tests for known ISO boundaries and fractional lifespan endpoints.
+- Month view now computes month starts, titles, states, and stages directly from UTC components.
+- Year view now computes birthday anniversaries, titles, and states directly from UTC components.
+- Leap-day anniversaries use February 28 in non-leap years.
+- Added deterministic regressions that run Month/Year rendering under UTC, Los Angeles, London, Tokyo, and Auckland settings without local-time `dateFns` helpers.
 - Opened:
   - Issue #31 for a future Calendar/Birthday week-alignment toggle.
-  - Issue #32 for the Calendar timezone bug fixed by the current changes.
+  - Issue #35 for broader worldwide timezone correctness.
+- Issue #32 is closed; issues #33 and #34 are fixed locally pending merge.
 - Local baseline validated:
-  - `npm run verify` -> 69/69 tests passing
-  - `npm run test:coverage` -> 96.17% statements, 81.97% branches, 100% functions, 97.74% lines
+  - `conda run -n base npm run verify` -> 69/69 tests passing
+  - `conda run -n base npm run test:coverage` -> 95.81% statements, 82.62% branches, 100% functions, 97.36% lines
 
 ## Next Action
-Commit the behavior fixes and documentation updates, then merge and close issue #32.
+Commit the Month/Year fixes and documentation updates, then merge and close issues #33 and #34.
 
 ## Decisions
 - Adopted Node 20 as CI baseline due to `vitest@4` engine requirements.
@@ -30,6 +34,8 @@ Commit the behavior fixes and documentation updates, then merge and close issue 
 - Use the browser's local calendar date for user-facing birthdate validity, while normalizing accepted date-only values to UTC.
 - Keep Calendar weeks as the default alignment; track Birthday-aligned weeks separately in issue #31.
 - Compute Calendar ISO boundaries with native UTC helpers instead of local-time `date-fns` functions.
+- Compute Month boundaries and Year birthday anniversaries with native UTC helpers.
+- Treat February 28 as the non-leap-year anniversary for February 29 births.
 
 ## Blockers
 None.
@@ -39,10 +45,14 @@ None.
 - `js/gridRenderer.js`
 - `tests/unit/ui.test.js`
 - `tests/unit/gridRenderer.calendar.test.js`
+- `tests/unit/gridRenderer.months.test.js`
+- `tests/unit/gridRenderer.years.test.js`
+- `tests/unit/gridRenderer.failure.test.js`
 - `README.md`
 - `docs/ui.md`
 - `docs/gridRenderer.md`
 - `docs/2026-07-27-changes.md`
+- `docs/2026-07-28-changes.md`
 - `.kilocode/rules/memory-bank/activeContext.md`
 - `.kilocode/rules/memory-bank/architecture.md`
 - `.kilocode/rules/memory-bank/progress.md`
@@ -53,7 +63,7 @@ None.
 - Should CI include coverage thresholds (`npm run test:coverage`) as an additional gate?
 - Should the project adopt stricter type checking over time (e.g., gradual `checkJs` opt-in per file)?
 - Should the optional `date-fns-tz` CDN integration be repaired, upgraded, or removed in favor of native UTC helpers?
-- How should Month and Year views be migrated away from local-time `date-fns` arithmetic?
+- How should issue #35 reconcile local-calendar current-period behavior with deterministic UTC-generated boundaries?
 
 ## Learnings & Insights
 

--- a/.kilocode/rules/memory-bank/product.md
+++ b/.kilocode/rules/memory-bank/product.md
@@ -20,7 +20,7 @@ It is **not** intended as a precise predictive tool but rather as a thought-prov
   * **Clarity:** The visualization should be immediately understandable. The grid, colors, and states (past/present/future) should be intuitive. Explanations and keys should be easily accessible when needed. The current view should be clearly indicated.
   * **Simplicity:** The initial interaction should be focused and straightforward (enter details, calculate). Complexity is revealed progressively.
   * **Impact:** The visualization should be striking and encourage contemplation. Placing the grid prominently after results enhances impact.
-  * **Accuracy (within scope):** Calculations should correctly reflect age and use the specified actuarial data. Date handling across timezones/DST must be deterministic; Calendar weeks now meet this requirement, while Month/Year follow-up remains tracked in current context.
+  * **Accuracy (within scope):** Calculations should correctly reflect age and use the specified actuarial data. Date handling across timezones/DST must be deterministic; Calendar, Month, and Year boundaries now meet this requirement, while broader local-time correctness remains tracked in issue #35.
   * **Responsiveness:** The experience should be seamless across desktop, tablet, and mobile devices.
   * **Transparency:** Explanations for visualization nuances (53-week years, calendar view) and a clear disclaimer about the nature of the estimates are essential.
   * **Visual Cohesion:** Controls and related information should feel integrated with the visualization they affect.
@@ -69,7 +69,7 @@ It is **not** intended as a precise predictive tool but rather as a thought-prov
 * **Fixed Grid Container Width:** Ensures a stable and predictable user experience when switching between views.
 * **Dynamic Block Sizing (Months/Years):** Makes less granular views visually fill the available space effectively.
 * **Clear Disclaimer & Explanations:** Manages user expectations and clarifies visualization nuances.
-* **UTC Date Handling:** Accepted date-only input is normalized to UTC. Calendar view computes ISO week-year boundaries directly from UTC date components so 52/53-week counts and Monday starts do not drift with browser timezone.
+* **UTC Date Handling:** Accepted date-only input is normalized to UTC. Calendar, Month, and Year views compute boundaries and titles directly from UTC date components so they do not drift with browser timezone. Leap-day Year anniversaries use February 28 in non-leap years.
 * **Progressive Reveal:** Creates a cleaner starting point focused on input.
 * **Consolidated & Collapsible Guide/Key:** Keeps secondary information accessible but visually tidy. Explanation text refined for clarity and user-friendliness.
 * **Integrated & Nested Controls Header:** Creates a strong visual connection between controls and visualization. Tooltips reduce clutter.

--- a/.kilocode/rules/memory-bank/progress.md
+++ b/.kilocode/rules/memory-bank/progress.md
@@ -1,55 +1,53 @@
 # Progress Log - Life Visualized
 
-## Latest Update (2026-07-27)
+## Latest Update (2026-07-28)
 - Status: Active
-- Summary: Behavior audit fixes completed for immediate validation, full reset behavior, and timezone-independent Calendar weeks.
+- Summary: Issues #33 and #34 are fixed locally with native UTC Month/Year generation and regression coverage.
 
 ## Recent Changes
-- Immediate input validation added in [`js/ui.js`](js/ui.js:1):
-  - Birthdate maximum is yesterday in the browser's local calendar.
-  - Calculate remains disabled for today, future, malformed, or incomplete input.
-- Start Over now resets inputs, results, renderer data, selected view, ARIA state, and focus.
-- Calendar rendering corrected in [`js/gridRenderer.js`](js/gridRenderer.js:1):
-  - Native UTC ISO week helpers replace timezone-sensitive local `date-fns` calculations.
-  - 52/53-week counts and Monday start dates are deterministic.
-  - Fractional lifespan endpoints and UTC-formatted titles are preserved.
-- GitHub issues created:
-  - #31 Add week-alignment toggle for age-based visualization.
-  - #32 Fix incorrect ISO week counts and dates in Calendar view.
+- Month rendering corrected in [`js/gridRenderer.js`](js/gridRenderer.js:1):
+  - Native UTC helpers replace `dateFns.startOfMonth`, `addMonths`, comparisons, and formatting.
+  - Exact fractional-lifespan block counts and unique month starts are preserved.
+  - Current-month state and life stages use corrected UTC month boundaries.
+- Year rendering corrected in [`js/gridRenderer.js`](js/gridRenderer.js:1):
+  - Native UTC birthday anniversaries replace local-time `dateFns.addYears`.
+  - Anniversary intervals determine past/present/future state.
+  - February 29 clamps to February 28 in non-leap years.
+- Issue #32 was merged through PR #37 and closed.
+- Issues #33 and #34 remain open until this branch reaches `main`.
 
 ## New/Updated Test Files
-- `tests/unit/ui.test.js` (immediate date validation and complete reset state)
-- `tests/unit/gridRenderer.calendar.test.js` (known ISO 52/53-week boundaries, unique starts, fractional endpoints)
+- `tests/unit/gridRenderer.months.test.js`
+- `tests/unit/gridRenderer.years.test.js`
+- `tests/unit/gridRenderer.failure.test.js`
 
 ## Completed Tasks
-- Audited primary UI flows in the local browser.
-- Fixed inactive-tab focus after recalculation.
-- Implemented full Start Over reset behavior.
-- Implemented immediate birthdate validity feedback.
-- Fixed Calendar view ISO week calculations across timezones.
-- Verified known ISO years in the Pacific-time browser runtime.
-- Local verification succeeds via `npm run verify` (69/69 tests pass).
+- Reproduced the Month and Year timezone defects.
+- Removed Month/Year dependence on local-time arithmetic and `date-fns-tz` formatting.
+- Added timezone-invariant regressions for UTC, Los Angeles, London, Tokyo, and Auckland settings.
+- Added exact fractional-lifespan count and unique-boundary checks.
+- Defined and tested leap-day anniversary behavior.
+- Browser-verified both issue reproductions and leap-day titles.
+- Local verification succeeds via `conda run -n base npm run verify` (69/69 tests pass).
 
 ## Remaining Work / Next Steps
-- Commit and merge current changes; close issue #32 after merge.
+- Commit and merge the current changes; close issues #33 and #34 after merge.
+- Continue issue #35 for worldwide local-time semantics outside Month/Year generation.
 - Implement issue #31 while keeping Calendar weeks as the default.
-- Correct remaining Month/Year timezone-sensitive date operations.
-- Decide whether to repair/remove the unavailable `date-fns-tz` browser global.
-- Decide whether to add coverage threshold enforcement in CI (branch threshold candidate).
+- Decide whether to remove the unavailable `date-fns-tz` browser dependency.
+- Decide whether to add coverage threshold enforcement in CI.
 
 ## Test Summary (current)
 - Commands:
-  - `npm run verify`
-  - `npm run test:run`
-  - `npm run test:coverage`
+  - `conda run -n base npm run verify`
+  - `conda run -n base npm run test:coverage`
 - Current result summary: 69 tests passing locally (0 failing), 11 test files.
 - Current coverage summary:
-  - Statements: `96.17%`
-  - Branches: `81.97%`
+  - Statements: `95.81%`
+  - Branches: `82.62%`
   - Functions: `100%`
-  - Lines: `97.74%`
+  - Lines: `97.36%`
 
 ## Notes
-- Local quality checks now have a single entrypoint (`npm run verify`) suitable for pre-PR runs.
-- CI now enforces lint/typecheck/tests in sequence for stronger baseline confidence.
-- Runtime app architecture remains static + CDN-based, but Calendar ISO calculations no longer rely on timezone library behavior.
+- Month/Year tests deliberately make local-time `dateFns` operations unusable so regressions cannot be hidden by UTC-only mocks.
+- Runtime architecture remains static and CDN-based. Only Weeks (Age) still relies on `date-fns` for boundary generation.

--- a/.kilocode/rules/memory-bank/tech.md
+++ b/.kilocode/rules/memory-bank/tech.md
@@ -10,11 +10,11 @@
 
 * **Runtime CDN dependencies:**
   * **`date-fns` v4.1.0:**
-  * **Usage:** Used by Age, Month, and Year renderers for date calculations and by renderers for date comparisons.
+  * **Usage:** Used by the Weeks (Age) renderer for week generation and comparisons. Calendar, Month, and Year boundaries use native UTC helpers.
   * **Integration:** Loaded via CDN (`https://cdn.jsdelivr.net/npm/date-fns@4.1.0/cdn.min.js`) in `index.html`. Accessed globally via the `dateFns` object.
   * **Constraint:** The application relies on this specific version (or compatible 4.x) being available globally. `gridRenderer.js` includes a basic check for its presence.
   * **`date-fns-tz` v1.3.7:**
-  * **Usage:** Intended as an optional timezone-aware formatting helper. Calendar view no longer depends on it and formats UTC dates directly.
+  * **Usage:** Intended as an optional timezone-aware formatting helper. Calendar, Month, and Year views no longer depend on it and format UTC dates directly.
   * **Integration:** Loaded via CDN (`https://cdn.jsdelivr.net/npm/date-fns-tz@1.3.7/dist/date-fns-tz.min.js`) in `index.html`. Accessed globally via `dateFnsTz`.
   * **Known runtime state:** The current CDN script does not expose `dateFnsTz` in the audited browser runtime, so remaining renderers use their core `date-fns` fallback paths.
 
@@ -52,10 +52,10 @@
 * Unit test files: `11`
 * Passing tests: `69`
 * Coverage:
-  * Statements: `96.17%`
-  * Branches: `81.97%`
+  * Statements: `95.81%`
+  * Branches: `82.62%`
   * Functions: `100%`
-  * Lines: `97.74%`
+  * Lines: `97.36%`
 ## 7. Additional Notes from Historical Context
 
 * The project has undergone multiple iterations of UX refinement focusing on clarity, simplicity, and accessibility.

--- a/.kilocode/rules/memory-bank/tests-plans-by-module.md
+++ b/.kilocode/rules/memory-bank/tests-plans-by-module.md
@@ -38,11 +38,11 @@ Brief: Separate, focused test plans for each core module to keep the memory bank
   1. Helpers: `getLifeStageKey` boundary checks; `calculateAgeAtDate` correctness across UTC dates.
   2. `renderAgeGrid`: enforce max 53 weeks when `eachWeekOfInterval` yields 54; confirm past/present/future classes.
   3. `renderCalendarGrid`: native UTC ISO week/year handling for known 52/53-week years, unique Monday starts, fractional lifespan endpoints, out-of-bounds weeks, and per-week age/stage correctness.
-  4. `renderMonthsGrid`: 12 months per row; month state classification and life stage assignment.
-  5. `renderYearsGrid`: decade rows (10/year); current year highlighting; state classes.
+  4. `renderMonthsGrid`: exact fractional-lifespan counts, unique native UTC month starts, state classification, and life-stage assignment across representative timezones.
+  5. `renderYearsGrid`: exact fractional-lifespan counts, native UTC anniversaries, decade rows, anniversary-based state classes, and February 29 clamping.
   6. Failure modes: missing `dateFns` -> DOM shows error-message; missing DOM element param -> no throw.
-  7. Timezone regression: known ISO boundaries must produce identical counts/titles without relying on mocked `getISOWeeksInYear` values.
-- Test notes: Use JSDOM; mock only the remaining global `dateFns` comparison/functions required by each renderer. Calendar ISO boundaries should exercise the production UTC helpers.
+  7. Timezone regression: Calendar, Month, and Year boundaries must produce identical counts/titles without relying on UTC-only mocks of local-time `dateFns` functions.
+- Test notes: Use JSDOM; mock only the remaining global `dateFns` functions required by each renderer. Calendar, Month, and Year tests should exercise production UTC helpers directly.
 - Estimated effort: 6–12 tests
 
 ## js/ui.js
@@ -83,10 +83,10 @@ Brief: Separate, focused test plans for each core module to keep the memory bank
 - Unit test files: `11`
 - Tests passing: `69`
 - Coverage:
-  - Statements: `96.17%`
-  - Branches: `81.97%`
+  - Statements: `95.81%`
+  - Branches: `82.62%`
   - Functions: `100%`
-  - Lines: `97.74%`
+  - Lines: `97.36%`
 - Known residual branch gaps are concentrated in defensive renderer branches that are difficult to reach without brittle synthetic mocks.
 
 ## Implementation & Best Practices

--- a/.kilocode/rules/memory-bank/tests-plans.md
+++ b/.kilocode/rules/memory-bank/tests-plans.md
@@ -33,10 +33,10 @@ Brief summary: This file contains separated plans for unit testing each core mod
   1. Helper functions: `getLifeStageKey` boundary checks; `calculateAgeAtDate` date cases.
   2. renderAgeGrid: enforce max 53 weeks when `eachWeekOfInterval` returns 54 (edge test exists).
   3. renderCalendarGrid: native UTC ISO boundaries for known 52/53-week years, unique Monday starts, fractional lifespan endpoints, out-of-bounds weeks, and present/past/future classification.
-  4. renderMonthsGrid: 12 months per row; month state classification and life stage assignment.
-  5. renderYearsGrid: decade rows (10 per row); current year highlighting; state classes.
+  4. renderMonthsGrid: exact fractional-lifespan counts, unique native UTC month boundaries, state classification, and life-stage assignment across representative timezones.
+  5. renderYearsGrid: exact fractional-lifespan counts, native UTC anniversaries, decade rows, anniversary-based state classes, and explicit leap-day behavior.
   6. Failure modes: missing `dateFns` -> renderer writes error message; missing DOM element param.
-- Test notes: Use JSDOM and mock global.dateFns with minimal functions per test; reuse [`tests/unit/gridRenderer.edge.test.js`](tests/unit/gridRenderer.edge.test.js:1).
+- Test notes: Use JSDOM. Month/Year tests should poison local-time `dateFns` functions so production UTC helpers are exercised directly.
 - Estimated effort: 6–10 test cases
 
 ## js/ui.js

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ This collaborative approach enabled the creation of this MVP, serving as both a 
   * Multiple Views:
     * Weeks (arranged by Age Year)
     * Weeks (arranged by ISO Calendar Year with timezone-independent 52/53-week handling)
-    * Months (arranged by Age Year)
-    * Years (arranged by Decade)
+    * Months (arranged by Age Year with timezone-independent UTC boundaries)
+    * Years (arranged by Decade with timezone-independent UTC anniversaries)
   * **Axis Labels:** Dynamically populated top and left axis labels (e.g., Week Number/Month Name/Decade for the top axis, Age Year/Calendar Year for the left axis) provide clear context for each grid view.
   * **Color-Coding:** Blocks are colored to distinguish past, present, future, and general life stages.
 * **User Interface:**
@@ -78,7 +78,7 @@ This collaborative approach enabled the creation of this MVP, serving as both a 
 ## Technology Stack
 
 * **Frontend:** HTML5, CSS3 (including Flexbox, CSS Variables, `calc()`, `aspect-ratio`), Vanilla JavaScript (ES6+ Modules)
-* **Core Dependencies:** `date-fns` v4.1.0 and optional `date-fns-tz` v1.3.7 are loaded via CDN. Calendar ISO calculations use native UTC helpers; other renderers continue to use `date-fns`. These libraries are used under the MIT License.
+* **Core Dependencies:** `date-fns` v4.1.0 and optional `date-fns-tz` v1.3.7 are loaded via CDN. Calendar, Month, and Year date boundaries use native UTC helpers; the Weeks (Age) renderer continues to use `date-fns`. These libraries are used under the MIT License.
 * **Dev Tooling:** Vitest, JSDOM, c8, ESLint (flat config), and TypeScript (`tsc --noEmit` for project typecheck gate).
 * **Development:** Requires a simple local HTTP server (due to ES Modules). No build process currently.
 

--- a/docs/2026-07-27-changes.md
+++ b/docs/2026-07-27-changes.md
@@ -30,9 +30,9 @@ Notes:
 
 - Calendar weeks remain the default alignment.
 - Issue #31 tracks a future toggle between Calendar and Birthday-aligned weeks.
-- Issue #32 is fixed locally and should remain open until the change reaches `main`.
+- Issue #32 subsequently reached `main` through PR #37 and is closed.
 - `date-fns-tz` did not expose its expected browser global during the audit; Calendar view no longer depends on it.
-- Month and Year renderers still require a follow-up review of local-time `date-fns` operations.
+- Month and Year follow-up was tracked in issues #33 and #34 and addressed in the subsequent 2026-07-28 change set.
 - Local validation completed in the conda development environment:
   - `npm run verify`: 11 test files, 69 tests passing.
   - `npm run test:coverage`: 96.17% statements, 81.97% branches, 100% functions, 97.74% lines.

--- a/docs/2026-07-28-changes.md
+++ b/docs/2026-07-28-changes.md
@@ -1,0 +1,31 @@
+# Changes — 2026-07-28
+
+Summary:
+
+- Fixed Month view timezone drift tracked in issue #33:
+  - Generate exactly `ceil(totalLifespanYearsEst * 12)` UTC month boundaries.
+  - Classify current month and life stages from corrected UTC month starts.
+  - Format every `Starts UTC` title directly from UTC date components.
+- Fixed Year view timezone drift tracked in issue #34:
+  - Generate exactly `ceil(totalLifespanYearsEst)` UTC birthday anniversaries.
+  - Classify past, present, and future blocks from consecutive anniversary boundaries.
+  - Define February 29 anniversaries as February 28 in non-leap years.
+  - Format every `Starts UTC` title directly from UTC date components.
+- Removed Month/Year boundary and title dependence on local-time `date-fns` operations and the unavailable `date-fns-tz` browser global.
+- Reworked regression tests to exercise production UTC helpers:
+  - Verify identical Month/Year output under UTC, Los Angeles, London, Tokyo, and Auckland timezone settings.
+  - Verify exact fractional-lifespan block counts and unique boundaries.
+  - Verify life-stage assignment from corrected Month boundaries.
+  - Verify leap-day anniversary sequences and present-year state.
+- Browser verification in the Pacific-time runtime:
+  - `2000-01-01` Month Age 0/Month 1 starts `2000-01-01`.
+  - `1990-06-15` Year Age 0 starts `1990-06-15`.
+  - `2000-02-29` anniversaries use Feb 28 for 2001-2003 and Feb 29 for 2004.
+- Local validation completed in the conda development environment:
+  - `npm run verify`: 11 test files, 69 tests passing.
+  - `npm run test:coverage`: 95.81% statements, 82.62% branches, 100% functions, 97.36% lines.
+
+Follow-up:
+
+- Issue #35 continues broader worldwide local-time correctness work outside Month/Year boundary generation.
+- Weeks (Age) still uses local-time `date-fns` operations and remains a follow-up risk.

--- a/docs/gridRenderer.md
+++ b/docs/gridRenderer.md
@@ -18,8 +18,9 @@ Public API
 
 Key internal concepts
 - LIFE_STAGES array and getLifeStageKey(age)
-- UTC-normalized date handling; Calendar ISO boundaries use native UTC helpers while other views rely on global `dateFns` v4.x
-- `startOfISOWeekUTC`, `getISOWeekYearUTC`, `getISOWeekStartUTC`, and `getISOWeeksInYearUTC`
+- UTC-normalized date handling; Calendar, Month, and Year boundaries use native UTC helpers while Weeks (Age) still relies on global `dateFns` v4.x
+- UTC month/year arithmetic and formatting through `addMonthsUTC`, `addYearsUTC`, `startOfMonthUTC`, and `formatUTCDate`
+- Calendar helpers `startOfISOWeekUTC`, `getISOWeekYearUTC`, `getISOWeekStartUTC`, and `getISOWeeksInYearUTC`
 - DocumentFragment usage for performance
 - Week-generation logic for ISO weeks with handling for 52/53 week years and edge cases near birthdays
 
@@ -38,11 +39,13 @@ Behavioral details & edge cases
   - Preserves fractional lifespan estimates through UTC month arithmetic and formats `Starts UTC` titles from UTC components.
   - Marks blocks outside lifespan as `out-of-bounds`.
 - Months:
-  - Renders up to ceil(totalYears * 12) month blocks grouped in 12-per-row.
-  - Uses `startOfMonth` for month boundaries.
+  - Renders exactly ceil(totalYears * 12) month blocks grouped in 12-per-row.
+  - Calculates month starts, current-month state, life stages, and `Starts UTC` titles from UTC date components without local-time `date-fns` operations.
 - Years:
-  - Renders year blocks grouped per-decade (10 per row).
-  - Year blocks represent the whole year starting at the birthday anniversary.
+  - Renders exactly ceil(totalYears) year blocks grouped per-decade (10 per row).
+  - Year blocks represent birthday-anniversary intervals calculated in UTC.
+  - Leap-day anniversaries use February 28 in non-leap years and return to February 29 in leap years.
+  - Past/present/future state and `Starts UTC` titles use the corrected UTC anniversary sequence.
 
 State classification
 - Each block gets a `stage-{key}` class via `getLifeStageKey(age)`.
@@ -59,7 +62,8 @@ Refactor considerations
 
 Testing guidance
 - Create `tests/grid-renderer-smoke.html` that imports the module and calls each renderer with deterministic inputs.
-- Validate known 52/53-week ISO years, unique block titles, UTC Monday starts, and fractional lifespan endpoints.
+- Validate known 52/53-week ISO years, unique block titles, UTC Monday starts, Month/Year boundaries, leap-day anniversaries, and fractional lifespan counts.
+- Ensure Month/Year tests exercise production UTC helpers and remain identical under representative browser timezone settings.
 
 Performance notes
 - Already uses DocumentFragment; maintain this.

--- a/docs/gridUtils-api.md
+++ b/docs/gridUtils-api.md
@@ -6,7 +6,7 @@ Provide a small, focused utilities module to centralize common grid logic curren
 Goals
 - Extract pure date and block-generation helpers.
 - Provide a small block element factory that preserves existing CSS/class conventions.
-- Keep UTC/date-fns assumptions explicit.
+- Keep native UTC and remaining Weeks (Age) `date-fns` assumptions explicit.
 - Maintain ARIA/title metadata and DocumentFragment-friendly rendering.
 
 Design Principles
@@ -27,10 +27,11 @@ Public API (proposed)
   - Convenience over getWeeksForInterval for age-row logic (handles birthday boundaries).
 
 - getMonthsForLifespan(birthDateUTC, totalYears) -> {start:Date, age:number, monthIndex:number}[]
-  - Returns month start dates and metadata grouped by life-year when needed.
+  - Returns exactly `ceil(totalYears * 12)` UTC month-start records.
 
 - getYearsForLifespan(birthDateUTC, totalYears) -> {start:Date, age:number}[]
-  - Year-start metadata for year blocks.
+  - Returns exactly `ceil(totalYears)` UTC birthday-anniversary records.
+  - Clamps February 29 to February 28 in non-leap years.
 
 - classifyBlockByDate(blockStartUTC, birthDateUTC, estimatedEndUTC) -> { stageKey:string, state: 'past'|'present'|'future'|'out-of-bounds' }
   - Encapsulates life-stage determination (`getLifeStageKey`) and state (compare to now / estimated end).
@@ -62,20 +63,20 @@ Example: Months view (conceptual)
 
 Migration plan (incremental)
 1. Add [`js/gridUtils.js`](js/gridUtils.js:1) with the pure helpers and small DOM factories plus a test harness (`tests/gridUtils.test.html`).
-2. Replace the Months rendering in [`js/gridRenderer.js`](js/gridRenderer.js:1) to call the helpers and factories (non-breaking change).
+2. Extract the existing native UTC Month/Year generation in [`js/gridRenderer.js`](js/gridRenderer.js:1) into helpers and factories without changing behavior.
 3. Smoke test visually and via console logs; fix any mismatch in class names/titles.
-4. Refactor Weeks-Age, Weeks-Calendar, Years similarly, keeping each change isolated and reviewed.
+4. Refactor Weeks-Age and Weeks-Calendar similarly, keeping each change isolated and reviewed.
 5. Remove duplicated logic and update [`js/ui.js`](js/ui.js:1) docs/architecture.
 
 Performance & Accessibility notes
 - Keep using DocumentFragment in renderRow to avoid layout thrash.
 - makeBlockElement should set title attributes and preserve `role`/`aria-*` as needed.
-- Keep UTC semantics and date-fns dependency; centralize date-fns calls in utils for consistent behavior.
+- Keep UTC semantics explicit and isolate the remaining Weeks (Age) `date-fns` calls.
 - Preserve existing CSS class names (stage-{key}, present/past/future/out-of-bounds) to avoid large stylesheet changes.
 
 Next actions
 - Implement [`js/gridUtils.js`](js/gridUtils.js:1) based on this sketch (I can start when you approve).
-- Refactor Months as a proof-of-concept, then proceed view-by-view.
+- Extract Months and Years first because their native UTC behavior is already covered, then proceed view-by-view.
 
 References
 - Current renderer: [`js/gridRenderer.js`](js/gridRenderer.js:1)

--- a/docs/gridUtils-tests.md
+++ b/docs/gridUtils-tests.md
@@ -39,7 +39,7 @@ console.log('Age 3 weeks (count):', age3Weeks.length);
 
 Example: getMonthsForLifespan
 const months = getMonthsForLifespan(birthUTC, 3); // 3 years => 36 months
-console.assert(months.length >= 36, 'getMonthsForLifespan: expected at least total months');
+console.assert(months.length === 36, 'getMonthsForLifespan: expected exact total months');
 console.log('First 3 month starts:', months.slice(0,3).map(m=>m.start.toISOString().slice(0,10)));
 
 Example: classifyBlockByDate

--- a/docs/gridUtils.md
+++ b/docs/gridUtils.md
@@ -17,10 +17,11 @@ Public API (detailed)
   - Convenience wrapper: computes the interval [birthday+age, birthday+age+1y) and returns week-starts.
 
 - getMonthsForLifespan(birthDateUTC: Date, totalYears: number): { start: Date, age: number, monthIndex: number }[]
-  - Returns month-start metadata for each month up to the estimated lifespan.
+  - Returns exactly `ceil(totalYears * 12)` UTC month-start records.
 
 - getYearsForLifespan(birthDateUTC: Date, totalYears: number): { start: Date, age: number }[]
-  - Returns year-start metadata for each year up to the estimated lifespan.
+  - Returns exactly `ceil(totalYears)` UTC birthday-anniversary records.
+  - Clamps February 29 to February 28 in non-leap years.
 
 - classifyBlockByDate(blockStartUTC: Date, birthDateUTC: Date, estimatedEndUTC: Date, opts?: { nowUTC?: Date })
   - Returns { stageKey: string, state: 'past'|'present'|'future'|'out-of-bounds' }.
@@ -38,7 +39,7 @@ Types & constants to export
 
 Design notes
 - Pure helpers whenever possible; allow injection of `nowUTC` for deterministic tests.
-- Centralize `date-fns` usage here to keep renderers thin.
+- Isolate the remaining Weeks (Age) `date-fns` usage while preserving native UTC helpers for other views.
 - Preserve existing CSS class names and titles to avoid stylesheet churn.
 - Keep DOM factories minimal and side-effect free beyond element creation.
 
@@ -64,9 +65,9 @@ Testing & harness
 
 Migration path (incremental)
 1. Add `js/gridUtils.js` exporting pure helpers and constants.
-2. Refactor [`js/gridRenderer.js`](js/gridRenderer.js:1) Months view to use helpers (non-breaking).
+2. Extract the existing native UTC Month/Year generation from [`js/gridRenderer.js`](js/gridRenderer.js:1) without changing behavior.
 3. Smoke test via the browser (`index.html`) and `tests/grid-renderer-smoke.html`.
-4. Refactor Weeks-Age and Weeks-Calendar, then Years, verifying after each change.
+4. Refactor Weeks-Age and Weeks-Calendar, verifying after each change.
 5. Remove duplication from `js/gridRenderer.js` and update docs.
 
 Performance & accessibility notes

--- a/docs/memory-bank.md
+++ b/docs/memory-bank.md
@@ -1,5 +1,19 @@
 # Memory Bank
 
+## 2026-07-28
+
+- Fixed Month and Year timezone drift tracked in issues #33 and #34:
+  - Native UTC helpers now generate Month boundaries and Year birthday anniversaries.
+  - Month/Year titles no longer depend on `date-fns-tz` or local-time formatting.
+  - Year state classification follows anniversary intervals.
+  - February 29 anniversaries use February 28 in non-leap years.
+- Added timezone-invariant regression coverage under UTC, Los Angeles, London, Tokyo, and Auckland settings.
+- Browser-verified the original Month and Year reproductions and leap-day title sequence.
+- Verification:
+  - `conda run -n base npm run verify` passes.
+  - Baseline: 11 test files, 69 tests passing.
+  - Coverage: 95.81% statements, 82.62% branches, 100% functions, 97.36% lines.
+
 ## 2026-07-27
 
 - Behavior audit created GitHub issues:

--- a/js/gridRenderer.js
+++ b/js/gridRenderer.js
@@ -6,8 +6,9 @@
  *
  * Exports: `renderAgeGrid`, `renderCalendarGrid`, `renderMonthsGrid`, `renderYearsGrid`.
  *
- * Relies on the global `dateFns` object (v4.1.0+) for UTC-based date calculations.
- * Expects input `birthDate` to be pre-normalized to UTC midnight by the calling module.
+ * Requires the global `dateFns` object (v4.1.0+); Weeks (Age) uses its date operations,
+ * while Calendar, Month, and Year boundaries use native UTC helpers. Expects input
+ * `birthDate` to be pre-normalized to UTC midnight by the calling module.
  * Defines `LIFE_STAGES` and helper functions internally. Uses `DocumentFragment` for
  * efficient DOM manipulation. Renders content into a specific `gridContentAreaElement`.
  */
@@ -37,8 +38,8 @@ function toUTCStartOfDay(date) {
     return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
 }
 
-function addYearsUTC(date, years) {
-    const targetMonthIndex = date.getUTCMonth() + Math.trunc(years * 12);
+function addMonthsUTC(date, months) {
+    const targetMonthIndex = date.getUTCMonth() + months;
     const targetYear = date.getUTCFullYear() + Math.floor(targetMonthIndex / 12);
     const targetMonth = ((targetMonthIndex % 12) + 12) % 12;
     const lastDayOfTargetMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
@@ -47,6 +48,14 @@ function addYearsUTC(date, years) {
         targetMonth,
         Math.min(date.getUTCDate(), lastDayOfTargetMonth)
     ));
+}
+
+function addYearsUTC(date, years) {
+    return addMonthsUTC(date, Math.trunc(years * 12));
+}
+
+function startOfMonthUTC(date) {
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
 }
 
 function startOfISOWeekUTC(date) {
@@ -362,11 +371,7 @@ function renderMonthsGrid(inputBirthDate, totalLifespanYearsEst, gridContentArea
         // --- Date Setup (UTC) ---
         const birthDateUTC = inputBirthDate; // Already normalized by ui.js
         const nowUTC = toUTCStartOfDay(new Date());
-        const estimatedEndDateRough = dateFns.addYears(birthDateUTC, totalLifespanYearsEst);
-        const estimatedEndDateUTC = toUTCStartOfDay(estimatedEndDateRough);
-
-        // Calculate the start of the *current* month in UTC for comparison
-        const currentMonthStartDateUTC = dateFns.startOfMonth(nowUTC);
+        const currentMonthStartDateUTC = startOfMonthUTC(nowUTC);
 
         // Calculate total months to potentially render based on estimated lifespan
         const totalEstimatedMonths = Math.ceil(totalLifespanYearsEst * 12);
@@ -391,14 +396,7 @@ function renderMonthsGrid(inputBirthDate, totalLifespanYearsEst, gridContentArea
                 fragment.appendChild(currentMonthRow);
             }
 
-            // Calculate the start date of this specific month in the person's life
-            // Add 'monthIndex' months to the birth date, then find the start of that month.
-            const monthStartDateUTC = dateFns.startOfMonth(dateFns.addMonths(birthDateUTC, monthIndex));
-
-            // Don't render blocks for months that start after the estimated end date
-            if (dateFns.isAfter(monthStartDateUTC, estimatedEndDateUTC)) {
-                continue;
-            }
+            const monthStartDateUTC = startOfMonthUTC(addMonthsUTC(birthDateUTC, monthIndex));
 
             const monthBlock = document.createElement('div');
             monthBlock.classList.add('month-block'); // Class for month-specific styling
@@ -411,16 +409,14 @@ function renderMonthsGrid(inputBirthDate, totalLifespanYearsEst, gridContentArea
             let stateClass = '';
             const yearOfLife = Math.floor(monthIndex / 12); // Age year
             const monthOfLife = (monthIndex % 12) + 1; // 1-based month index within the age year
-            let formattedStart = (typeof dateFnsTz !== 'undefined' && dateFnsTz.formatInTimeZone)
-                ? dateFnsTz.formatInTimeZone(monthStartDateUTC, 'UTC', 'yyyy-MM-dd')
-                : dateFns.format(monthStartDateUTC, 'yyyy-MM-dd');
+            const formattedStart = formatUTCDate(monthStartDateUTC);
             let title = `Age ${yearOfLife}, Month ${monthOfLife} (Starts UTC: ${formattedStart})`;
 
             // Determine past/present/future by comparing the start date of this month
             // with the start date of the current actual month.
             if (monthStartDateUTC.getTime() === currentMonthStartDateUTC.getTime()) {
                 stateClass = 'present'; title += ' (Current month)';
-            } else if (dateFns.isBefore(monthStartDateUTC, currentMonthStartDateUTC)) {
+            } else if (monthStartDateUTC < currentMonthStartDateUTC) {
                 stateClass = 'past';
             } else {
                 stateClass = 'future';
@@ -468,11 +464,6 @@ function renderYearsGrid(inputBirthDate, totalLifespanYearsEst, gridContentAreaE
         // --- Date Setup (UTC) ---
         const birthDateUTC = inputBirthDate; // Already normalized by ui.js
         const nowUTC = toUTCStartOfDay(new Date());
-        const estimatedEndDateRough = dateFns.addYears(birthDateUTC, totalLifespanYearsEst);
-        const estimatedEndDateUTC = toUTCStartOfDay(estimatedEndDateRough);
-
-        // Calculate current age in whole years for state determination (past/present/future)
-        const currentAge = calculateAgeAtDate(nowUTC, birthDateUTC);
 
         // Calculate total years to potentially render (ceiling of estimated lifespan)
         const totalEstimatedYears = Math.ceil(totalLifespanYearsEst);
@@ -497,14 +488,8 @@ function renderYearsGrid(inputBirthDate, totalLifespanYearsEst, gridContentAreaE
                 fragment.appendChild(currentDecadeRow);
             }
 
-            // Calculate the start date of this specific year of life
-            const yearStartDateUTC = toUTCStartOfDay(dateFns.addYears(birthDateUTC, yearIndex));
-
-            // Don't render blocks for years that start after the estimated end date
-            // Note: A year block represents the *entire* year starting at yearIndex
-            if (dateFns.isAfter(yearStartDateUTC, estimatedEndDateUTC)) {
-                continue;
-            }
+            const yearStartDateUTC = addYearsUTC(birthDateUTC, yearIndex);
+            const nextYearStartDateUTC = addYearsUTC(birthDateUTC, yearIndex + 1);
 
             const yearBlock = document.createElement('div');
             yearBlock.classList.add('year-block'); // Class for year-specific styling
@@ -515,16 +500,12 @@ function renderYearsGrid(inputBirthDate, totalLifespanYearsEst, gridContentAreaE
             yearBlock.classList.add(`stage-${stageKey}`);
 
             let stateClass = '';
-            let formattedStart = (typeof dateFnsTz !== 'undefined' && dateFnsTz.formatInTimeZone)
-                ? dateFnsTz.formatInTimeZone(yearStartDateUTC, 'UTC', 'yyyy-MM-dd')
-                : dateFns.format(yearStartDateUTC, 'yyyy-MM-dd');
+            const formattedStart = formatUTCDate(yearStartDateUTC);
             let title = `Age ${ageForThisYear} (Starts UTC: ${formattedStart})`;
 
-            // Determine past/present/future based on comparing the age represented by this block
-            // with the pre-calculated current age.
-            if (ageForThisYear < currentAge) {
+            if (nextYearStartDateUTC <= nowUTC) {
                 stateClass = 'past';
-            } else if (ageForThisYear === currentAge) {
+            } else if (yearStartDateUTC <= nowUTC) {
                 stateClass = 'present'; title += ' (Current year)';
             } else {
                 stateClass = 'future';

--- a/tests/unit/gridRenderer.failure.test.js
+++ b/tests/unit/gridRenderer.failure.test.js
@@ -66,17 +66,18 @@ describe('gridRenderer failure modes', () => {
 
   it('shows an error message when months renderer throws unexpectedly', async () => {
     global.dateFns = {
-      startOfDay: () => {
-        throw new Error('forced months failure');
-      },
+      startOfDay: (date) => date,
     };
 
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { renderMonthsGrid } = await import('../../js/gridRenderer.js');
     const container = document.createElement('div');
-    const birthDateUTC = new Date(Date.UTC(2000, 0, 1));
+    const invalidBirthDate = new Date(Date.UTC(2000, 0, 1));
+    invalidBirthDate.getUTCMonth = () => {
+      throw new Error('forced months failure');
+    };
 
-    renderMonthsGrid(birthDateUTC, 1, container);
+    renderMonthsGrid(invalidBirthDate, 1, container);
 
     const err = container.querySelector('.error-message');
     expect(err).not.toBeNull();

--- a/tests/unit/gridRenderer.months.test.js
+++ b/tests/unit/gridRenderer.months.test.js
@@ -1,130 +1,99 @@
-/**
- * tests/unit/gridRenderer.months.test.js
- *
- * Tests for renderMonthsGrid (12 months per row, month state)
- */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupJSDOM, teardownJSDOM } from '../setup/jsdom-helper.js';
+
+const TEST_TIMEZONES = [
+  'UTC',
+  'America/Los_Angeles',
+  'Europe/London',
+  'Asia/Tokyo',
+  'Pacific/Auckland',
+];
 
 describe('gridRenderer months view', () => {
+  let dom;
+  let originalTimezone;
+  let localDateOperation;
+
   beforeEach(async () => {
-    // Reset module cache so we can inject a fresh global `dateFns` mock before importing the renderer.
     vi.resetModules();
-    // Make time deterministic for tests
     vi.useFakeTimers();
-    // Set system time to a fixed UTC moment (2025-07-01T00:00:00Z)
-    vi.setSystemTime(new Date(Date.UTC(2025, 6, 1, 0, 0, 0)));
+    vi.setSystemTime(new Date('2025-07-15T12:00:00Z'));
+    dom = await setupJSDOM();
+    originalTimezone = process.env.TZ;
 
-    // Create a JSDOM document/window so DOM APIs are available in Node test environment.
-    const { JSDOM } = await import('jsdom');
-    const dom = new JSDOM('<!doctype html><html><body></body></html>');
-    // Expose minimal globals used by the renderer and tests
-    global.window = dom.window;
-    global.document = dom.window.document;
-    global.HTMLElement = dom.window.HTMLElement;
-    global.Node = dom.window.Node;
-
-    // Minimal date-fns mock implementing only functions used by renderMonthsGrid for this test.
+    localDateOperation = vi.fn(() => {
+      throw new Error('renderer used a local-time date-fns operation');
+    });
     global.dateFns = {
-      startOfDay: (d) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())),
-      startOfMonth: (d) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1)),
-      addMonths: (d, n) => {
-        const dt = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
-        const year = dt.getUTCFullYear() + Math.floor((dt.getUTCMonth() + n) / 12);
-        const month = (dt.getUTCMonth() + n) % 12;
-        return new Date(Date.UTC(year, month, dt.getUTCDate()));
-      },
-      addYears: (d, n) => new Date(Date.UTC(d.getUTCFullYear() + n, d.getUTCMonth(), d.getUTCDate())),
-      isAfter: (a, b) => a.getTime() > b.getTime(),
-      isBefore: (a, b) => a.getTime() < b.getTime(),
-      format: (d, _fmt, _opts) => {
-        const y = d.getUTCFullYear();
-        const m = String(d.getUTCMonth() + 1).padStart(2, '0');
-        const day = String(d.getUTCDate()).padStart(2, '0');
-        return `${y}-${m}-${day}`;
-      },
+      startOfDay: localDateOperation,
+      startOfMonth: localDateOperation,
+      addMonths: localDateOperation,
+      addYears: localDateOperation,
+      isAfter: localDateOperation,
+      isBefore: localDateOperation,
+      format: localDateOperation,
+      version: '4.1.0-test',
     };
   });
 
   afterEach(() => {
-    // Clean up globals that were set in beforeEach
-    delete global.window;
-    delete global.document;
-    delete global.HTMLElement;
-    delete global.Node;
-    if (global.dateFns) delete global.dateFns;
-    // Restore timers and mocks
+    if (originalTimezone === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTimezone;
+    delete global.dateFns;
+    delete global.dateFnsTz;
+    teardownJSDOM(dom);
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it('renders 12 months per row and marks past/present/future months', async () => {
+  it('renders identical UTC boundaries and states across browser timezones', async () => {
     const { renderMonthsGrid } = await import('../../js/gridRenderer.js');
-    // Use the (fake) current UTC month to ensure a 'present' month exists deterministically.
-    const nowUTC = new Date();
-    // Use a birth date earlier than the current month so the rendered year contains past, present, and future months
-    const birthDateUTC = new Date(Date.UTC(nowUTC.getUTCFullYear(), nowUTC.getUTCMonth() - 6, 1));
-    const totalYears = 1; // render 12 months
-    const container = document.createElement('div');
 
-    renderMonthsGrid(birthDateUTC, totalYears, container);
+    for (const timezone of TEST_TIMEZONES) {
+      process.env.TZ = timezone;
+      const container = document.createElement('div');
 
-    // Should have month-row elements (one row for 12 months)
-    const rows = container.querySelectorAll('.month-row');
-    expect(rows.length).toBeGreaterThanOrEqual(1);
+      renderMonthsGrid(new Date('2025-01-01T00:00:00Z'), 1, container);
 
-    // Each month-row should contain exactly 12 .month-block children for a single-year render
-    const firstRow = rows[0];
-    const monthBlocks = firstRow.querySelectorAll('.month-block');
-    expect(monthBlocks.length).toBe(12);
+      const blocks = Array.from(container.querySelectorAll('.month-block'));
+      expect(blocks).toHaveLength(12);
+      expect(container.querySelectorAll('.month-row')).toHaveLength(1);
+      expect(blocks[0].title).toContain('Starts UTC: 2025-01-01');
+      expect(blocks[11].title).toContain('Starts UTC: 2025-12-01');
+      expect(container.querySelectorAll('.past')).toHaveLength(6);
+      expect(container.querySelectorAll('.present')).toHaveLength(1);
+      expect(container.querySelector('.present').title).toContain('Starts UTC: 2025-07-01');
+      expect(container.querySelectorAll('.future')).toHaveLength(5);
+    }
 
-    // Each row should never have more than 12 month blocks
-    rows.forEach(row => {
-      const blocks = row.querySelectorAll('.month-block');
-      expect(blocks.length).toBeLessThanOrEqual(12);
-    });
-
-    // There should be at least one 'present' class (for current month)
-    const present = container.querySelectorAll('.present');
-    expect(present.length).toBeGreaterThan(0);
-
-    // There should be at least one 'past' and one 'future' month-block
-    const past = container.querySelectorAll('.past');
-    const future = container.querySelectorAll('.future');
-    expect(past.length).toBeGreaterThan(0);
-    expect(future.length).toBeGreaterThan(0);
-
-    // Ensure titles contain 'Age' and 'Month'
-    const some = container.querySelector('.month-block');
-    expect(some).not.toBeNull();
-    expect(some.title).toContain('Age');
-    expect(some.title).toContain('Month');
+    expect(localDateOperation).not.toHaveBeenCalled();
   });
 
-  it('skips month blocks that start after estimated end date', async () => {
-    vi.resetModules();
-    global.dateFns = {
-      ...global.dateFns,
-      // Keep estimated end short for fractional lifespan, but move quickly for month indices.
-      addYears: (d, years) => {
-        const dt = new Date(d);
-        const monthsToAdd = Number.isInteger(years) ? years * 12 : 1;
-        return new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth() + monthsToAdd, dt.getUTCDate()));
-      },
-      addMonths: (d, months) => {
-        const dt = new Date(d);
-        const monthsToAdd = months * 2;
-        return new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth() + monthsToAdd, dt.getUTCDate()));
-      },
-    };
-
+  it('renders the exact fractional-lifespan month count without duplicate boundaries', async () => {
     const { renderMonthsGrid } = await import('../../js/gridRenderer.js');
-    const birthDateUTC = new Date(Date.UTC(2000, 0, 1));
     const container = document.createElement('div');
 
-    // ceil(0.25 * 12) => 3 iterations; with accelerated addMonths only first block remains in-range.
-    renderMonthsGrid(birthDateUTC, 0.25, container);
+    renderMonthsGrid(new Date('2000-01-31T00:00:00Z'), 0.25, container);
 
-    const monthBlocks = container.querySelectorAll('.month-block');
-    expect(monthBlocks.length).toBe(1);
+    const blocks = Array.from(container.querySelectorAll('.month-block'));
+    const starts = blocks.map((block) => block.title.match(/Starts UTC: ([0-9-]+)/)?.[1]);
+    expect(blocks).toHaveLength(Math.ceil(0.25 * 12));
+    expect(starts).toEqual(['2000-01-01', '2000-02-01', '2000-03-01']);
+    expect(new Set(starts).size).toBe(starts.length);
+    expect(localDateOperation).not.toHaveBeenCalled();
+  });
+
+  it('assigns life stages from corrected UTC month starts', async () => {
+    const { renderMonthsGrid } = await import('../../js/gridRenderer.js');
+    const container = document.createElement('div');
+
+    renderMonthsGrid(new Date('2000-01-15T00:00:00Z'), 1.1, container);
+
+    const blocks = Array.from(container.querySelectorAll('.month-block'));
+    expect(blocks).toHaveLength(14);
+    expect(blocks[12].title).toContain('Starts UTC: 2001-01-01');
+    expect(blocks[12].classList.contains('stage-infancy')).toBe(true);
+    expect(blocks[13].title).toContain('Starts UTC: 2001-02-01');
+    expect(blocks[13].classList.contains('stage-toddler')).toBe(true);
   });
 });

--- a/tests/unit/gridRenderer.years.test.js
+++ b/tests/unit/gridRenderer.years.test.js
@@ -1,160 +1,96 @@
-/**
- * tests/unit/gridRenderer.years.test.js
- *
- * Tests for renderYearsGrid (decade rows, current year highlight)
- */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupJSDOM, teardownJSDOM } from '../setup/jsdom-helper.js';
 
-function makeMockDateFns() {
-  function startOfDay(d) {
-    const dt = new Date(d);
-    return new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth(), dt.getUTCDate()));
-  }
-  function addYears(d, years) {
-    const dt = new Date(Date.UTC(d.getUTCFullYear() + years, d.getUTCMonth(), d.getUTCDate()));
-    return dt;
-  }
-  function startOfISOWeek(d) {
-    const dt = new Date(d);
-    const day = dt.getUTCDay() === 0 ? 7 : dt.getUTCDay();
-    const diff = day - 1;
-    return new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth(), dt.getUTCDate() - diff));
-  }
-  function format(d, _fmt, _opts) {
-    const dt = new Date(d);
-    const y = dt.getUTCFullYear();
-    const m = String(dt.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(dt.getUTCDate()).padStart(2, '0');
-    return `${y}-${m}-${day}`;
-  }
-  function isAfter(a, b) { return a.getTime() > b.getTime(); }
-  function isBefore(a, b) { return a.getTime() < b.getTime(); }
-
-  return { startOfDay, addYears, startOfISOWeek, format, isAfter, isBefore, version: '4.1.0-mock' };
-}
+const TEST_TIMEZONES = [
+  'UTC',
+  'America/Los_Angeles',
+  'Europe/London',
+  'Asia/Tokyo',
+  'Pacific/Auckland',
+];
 
 describe('gridRenderer years view', () => {
+  let dom;
+  let originalTimezone;
+  let localDateOperation;
+
   beforeEach(async () => {
     vi.resetModules();
-    // Create a JSDOM document/window so DOM APIs are available in Node test environment.
-    const { JSDOM } = await import('jsdom');
-    const dom = new JSDOM('<!doctype html><html><body></body></html>');
-    global.window = dom.window;
-    global.document = dom.window.document;
-    global.HTMLElement = dom.window.HTMLElement;
-    global.Node = dom.window.Node;
-
     vi.useFakeTimers();
-    // Freeze to 2025-07-01 so current age can be deterministic
-    vi.setSystemTime(new Date('2025-07-01T00:00:00Z'));
-    global.dateFns = makeMockDateFns();
+    vi.setSystemTime(new Date('2025-07-01T12:00:00Z'));
+    dom = await setupJSDOM();
+    originalTimezone = process.env.TZ;
+
+    localDateOperation = vi.fn(() => {
+      throw new Error('renderer used a local-time date-fns operation');
+    });
+    global.dateFns = {
+      startOfDay: localDateOperation,
+      addYears: localDateOperation,
+      isAfter: localDateOperation,
+      isBefore: localDateOperation,
+      format: localDateOperation,
+      version: '4.1.0-test',
+    };
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+    if (originalTimezone === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTimezone;
     delete global.dateFns;
+    delete global.dateFnsTz;
+    teardownJSDOM(dom);
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it('renders decades (10 years per row) and highlights the current year block', async () => {
+  it('renders identical UTC anniversaries and states across browser timezones', async () => {
     const { renderYearsGrid } = await import('../../js/gridRenderer.js');
-    const birthDateUTC = new Date(Date.UTC(2000, 6, 1)); // July 1, 2000
-    const totalYears = 30; // render 30 years
-    const container = document.createElement('div');
 
-    renderYearsGrid(birthDateUTC, totalYears, container);
+    for (const timezone of TEST_TIMEZONES) {
+      process.env.TZ = timezone;
+      const container = document.createElement('div');
 
-    // Should have decade-row elements (expect ceil(totalYears / 10))
-    const decades = container.querySelectorAll('.decade-row');
-    expect(decades.length).toBe(Math.ceil(totalYears / 10));
+      renderYearsGrid(new Date('1990-06-15T00:00:00Z'), 40, container);
 
-    // Year blocks should exist and count should be equal to totalYears (or slightly more if renderer includes padding)
-    const yearBlocks = container.querySelectorAll('.year-block');
-    expect(yearBlocks.length).toBeGreaterThanOrEqual(totalYears);
+      const blocks = Array.from(container.querySelectorAll('.year-block'));
+      expect(blocks).toHaveLength(40);
+      expect(container.querySelectorAll('.decade-row')).toHaveLength(4);
+      expect(blocks[0].title).toBe('Age 0 (Starts UTC: 1990-06-15)');
+      expect(container.querySelectorAll('.past')).toHaveLength(35);
+      expect(container.querySelectorAll('.present')).toHaveLength(1);
+      expect(container.querySelector('.present').title)
+        .toBe('Age 35 (Starts UTC: 2025-06-15) (Current year)');
+      expect(container.querySelectorAll('.future')).toHaveLength(4);
+    }
 
-    // Each decade row should contain at most 10 year-blocks
-    decades.forEach((row) => {
-      const blocks = row.querySelectorAll('.year-block');
-      expect(blocks.length).toBeLessThanOrEqual(10);
-    });
-
-    // There should be at least one 'present' class representing the current age/year
-    const present = container.querySelectorAll('.present');
-    expect(present.length).toBeGreaterThanOrEqual(1);
-
-    // The present block title should contain 'Current year' and indicate the correct year (2025)
-    const presentBlock = Array.from(container.querySelectorAll('.year-block')).find(b => b.classList.contains('present'));
-    expect(presentBlock).toBeDefined();
-    expect(presentBlock.title).toContain('Current year');
-    // Ensure the title contains the expected year string (from frozen system time 2025-07-01)
-    expect(presentBlock.title).toMatch(/2025/);
+    expect(localDateOperation).not.toHaveBeenCalled();
   });
 
-  it('skips rendering year blocks that start after estimated end date', async () => {
-    vi.resetModules();
-    global.dateFns = {
-      ...makeMockDateFns(),
-      // Force a short estimated end for fractional lifespan input, but larger jumps for integer year indices.
-      addYears: (d, years) => {
-        const dt = new Date(d);
-        const yearsToAdd = Number.isInteger(years) ? years * 2 : 1;
-        return new Date(Date.UTC(dt.getUTCFullYear() + yearsToAdd, dt.getUTCMonth(), dt.getUTCDate()));
-      },
-    };
-
+  it('preserves the existing fractional-lifespan year block count', async () => {
     const { renderYearsGrid } = await import('../../js/gridRenderer.js');
-    const birthDateUTC = new Date(Date.UTC(2000, 0, 1));
     const container = document.createElement('div');
 
-    // ceil(2.5) => 3 iterations, but only first block should remain within the forced short end date.
-    renderYearsGrid(birthDateUTC, 2.5, container);
+    renderYearsGrid(new Date('2000-01-01T00:00:00Z'), 2.5, container);
 
-    const yearBlocks = container.querySelectorAll('.year-block');
-    expect(yearBlocks.length).toBe(1);
+    const blocks = Array.from(container.querySelectorAll('.year-block'));
+    expect(blocks).toHaveLength(Math.ceil(2.5));
+    expect(blocks.map((block) => block.title.match(/Starts UTC: ([0-9-]+)/)?.[1]))
+      .toEqual(['2000-01-01', '2001-01-01', '2002-01-01']);
+    expect(localDateOperation).not.toHaveBeenCalled();
   });
 
-  it('renders an error message when years rendering throws unexpectedly', async () => {
-    vi.resetModules();
-    global.dateFns = {
-      ...makeMockDateFns(),
-      addYears: () => {
-        throw new Error('forced addYears failure');
-      },
-    };
-
+  it('uses February 28 for leap-day anniversaries in non-leap years', async () => {
+    vi.setSystemTime(new Date('2025-02-28T12:00:00Z'));
     const { renderYearsGrid } = await import('../../js/gridRenderer.js');
     const container = document.createElement('div');
 
-    renderYearsGrid(new Date(Date.UTC(2000, 0, 1)), 3, container);
+    renderYearsGrid(new Date('2000-02-29T00:00:00Z'), 30, container);
 
-    const err = container.querySelector('.error-message');
-    expect(err).not.toBeNull();
-    expect(err.textContent).toContain('Error generating years-based grid.');
-  });
-
-  it('uses UTC day boundaries for current-age state when date-fns-tz is unavailable', async () => {
-    vi.resetModules();
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-01-01T00:30:00Z'));
-
-    const shiftedStartOfDay = vi.fn((d) => {
-      const dt = new Date(d);
-      return new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth(), dt.getUTCDate() - 1));
-    });
-
-    global.dateFns = {
-      ...makeMockDateFns(),
-      startOfDay: shiftedStartOfDay,
-    };
-
-    const { renderYearsGrid } = await import('../../js/gridRenderer.js');
-    const container = document.createElement('div');
-
-    renderYearsGrid(new Date(Date.UTC(2000, 0, 1)), 30, container);
-
-    const presentBlock = container.querySelector('.year-block.present');
-    expect(presentBlock).not.toBeNull();
-    expect(presentBlock.title).toContain('Age 25');
-    expect(shiftedStartOfDay).not.toHaveBeenCalled();
+    const blocks = Array.from(container.querySelectorAll('.year-block'));
+    expect(blocks.slice(0, 5).map((block) => block.title.match(/Starts UTC: ([0-9-]+)/)?.[1]))
+      .toEqual(['2000-02-29', '2001-02-28', '2002-02-28', '2003-02-28', '2004-02-29']);
+    expect(container.querySelector('.present').title)
+      .toBe('Age 25 (Starts UTC: 2025-02-28) (Current year)');
   });
 });


### PR DESCRIPTION
## Summary
- generate Month boundaries with native UTC month arithmetic
- generate Year blocks from native UTC birthday anniversaries
- classify Month and Year states from corrected UTC boundaries
- define February 29 anniversaries as February 28 in non-leap years
- format `Starts UTC` titles without local-time `date-fns` or `date-fns-tz`
- update regression tests, documentation, and memory-bank records

## Root cause
The Month and Year renderers applied local-time `date-fns` operations to birthdates normalized to UTC midnight. In timezones west of UTC, the same instant can be the preceding local calendar date, shifting boundaries and titles backward.

## Impact
Month and Year boundaries, titles, life stages, and state classification are now deterministic across browser timezones. Fractional lifespan estimates retain exact block counts, and leap-day anniversary behavior is explicit.

## Validation
- `conda run -n base npm run verify`: 11 files, 69 tests passed
- `conda run -n base npm run test:coverage`: 95.81% statements, 82.62% branches, 100% functions, 97.36% lines
- regression output verified under UTC, Los Angeles, London, Tokyo, and Auckland timezone settings
- Pacific-time browser verified `2000-01-01` Month 1, `1990-06-15` Age 0, and the leap-day anniversary sequence

Fixes #33
Fixes #34