### PR TITLE
fix(date): make timezone behavior correct worldwide

### DIFF
--- a/.kilocode/rules/memory-bank/activeContext.md
+++ b/.kilocode/rules/memory-bank/activeContext.md
@@ -2,36 +2,36 @@
 
 ## Last Update
 - Date: 2026-07-28
-- Summary: Month and Year renderers now use timezone-independent UTC boundaries, titles, and state classification.
+- Summary: Issue #35 worldwide timezone correctness is implemented locally with a shared native date-only model.
 
 ## Recent Changes
-- Replaced Month view's local-time `date-fns` operations with native UTC helpers:
-  - Generates exactly `ceil(totalLifespanYearsEst * 12)` month blocks.
-  - Calculates month starts, current-month state, life stages, and `Starts UTC` titles from UTC components.
-  - Produces identical boundaries under UTC, Los Angeles, London, Tokyo, and Auckland timezone settings.
-- Replaced Year view's local-time anniversary operations and formatting:
-  - Generates exactly `ceil(totalLifespanYearsEst)` UTC birthday-anniversary blocks.
-  - Classifies past/present/future from consecutive anniversary boundaries.
-  - Defines February 29 anniversaries as February 28 in non-leap years.
-- Reworked Month/Year tests to poison local-time `dateFns` operations and exercise production UTC helpers.
-- Browser-verified the issue reproductions in the Pacific-time runtime:
-  - Month Age 0/Month 1 for `2000-01-01` starts `2000-01-01`.
-  - Year Age 0 for `1990-06-15` starts `1990-06-15`.
-  - Leap-day titles follow Feb 29 -> Feb 28 -> Feb 29 as years require.
-- GitHub tracking:
-  - Issue #32 is closed after PR #37 reached `main`.
-  - Issues #33 and #34 are fixed locally on `codex/fix-month-year-timezones`, pending merge.
-  - Issue #35 tracks broader worldwide local-time correctness.
-- Current local test baseline: 11 files / 69 tests passing.
+- Added `js/dateUtils.js`:
+  - Encodes the browser's local calendar date as UTC midnight for deterministic arithmetic.
+  - Provides native UTC month, year, ISO-week, formatting, and age helpers.
+  - Exposes the browser's resolved IANA timezone with a safe `UTC` fallback.
+- Age changes at local midnight in the user's browser timezone.
+- Current week, month, and age-year markers follow the user's local calendar.
+- Birthdates remain timezone-free calendar values encoded at UTC midnight.
+- Replaced all remaining `date-fns`/`date-fns-tz` runtime use and removed both CDN scripts.
+- Added regression coverage for:
+  - Los Angeles, UTC, London, Tokyo, and Auckland.
+  - Local midnight, UTC rollover, DST, leap days, month/year rollover, and ISO 52/53-week years.
+  - Renderer operation without external date-library globals.
+- Added targeted coverage for Weeks (Age) local rollover, UI validation across UTC rollover, native date-helper migration contracts, and a real-module calculation/render flow.
+- Current local test baseline: 13 files / 87 tests passing.
 - Current local coverage baseline:
-  - Statements `95.81%`
-  - Branches `82.62%`
+  - Statements `97.96%`
+  - Branches `87.09%`
   - Functions `100%`
-  - Lines `97.36%`
+  - Lines `98.15%`
+- Browser verification passed in the Pacific-time runtime for calculation, all four views, console errors, and Start Over reset.
+- GitHub tracking:
+  - Issues #33 and #34 are closed after PR #39 reached `main`.
+  - Issue #35 tracks the current branch.
+  - Issue #40 investigates maintained date libraries, module delivery, and Temporal as the timezone architecture grows.
 
 ## Next Steps
-- Commit, open a PR, and merge the Month/Year fixes; close issues #33 and #34 after they reach `main`.
-- Continue worldwide timezone correctness under issue #35, especially Weeks (Age), current-period semantics, and age calculation at local midnight.
-- Implement issue #31 with Calendar weeks as the default alignment.
-- Decide whether to remove the unavailable `date-fns-tz` runtime dependency.
+- Commit, open a PR linked with `Fixes #35`, and merge after CI passes.
+- Evaluate the native-helper tradeoff separately under issue #40; do not mix that investigation into the issue #35 behavior fix.
+- Implement issue #31 while keeping Calendar weeks as the default alignment.
 - Decide whether to enforce minimum branch coverage in CI.

--- a/.kilocode/rules/memory-bank/architecture.md
+++ b/.kilocode/rules/memory-bank/architecture.md
@@ -9,6 +9,7 @@
   * `main.js`: Application entry point, initializes UI.
   * `ui.js`: Controller/View-Model - Handles user interactions, manages UI state, orchestrates calls to other modules.
   * `calculator.js`: Model/Service - Performs core age and lifespan calculations.
+  * `dateUtils.js`: Shared date-only model - Converts local today to a UTC-encoded calendar date and provides native UTC calendar helpers.
   * `data.js`: Model/Data Source - Provides the static actuarial data.
   * `gridRenderer.js`: View/Rendering Engine - Generates the HTML for the different grid visualizations.
 * **Single HTML (`index.html`):** Contains the static structure and placeholders for dynamic content.
@@ -17,9 +18,9 @@
 ## 2. Key Technical Decisions & Patterns
 
 * **Vanilla JavaScript (ES Modules):** Chosen for simplicity and performance, avoiding framework overhead for this specific application scope. Enables clear separation of concerns via modules.
-* **UTC-Based Date Handling:**
-  * **Decision:** All internal date storage and calculations are performed using UTC to ensure consistency and avoid timezone/DST errors.
-  * **Pattern:** Input date strings are validated against the user's local calendar date, then normalized to UTC midnight in `ui.js`. Calendar, Month, and Year boundaries are calculated with native UTC helpers; Weeks (Age) still uses global `date-fns` operations.
+* **Local Calendar + UTC-Encoded Date Handling:**
+  * **Decision:** Birthdates are timezone-free calendar dates, while user-facing “today” follows the browser's local timezone.
+  * **Pattern:** Input and local-today calendar components are encoded at UTC midnight. All arithmetic and generated boundaries then use UTC methods to avoid timezone/DST drift.
 * **UI State Management (`ui.js`):**
   * **Pattern:** Simple module-level variables (`currentView`, `lastCalcData`) are used to maintain the selected view and the results of the last calculation.
   * **Rationale:** Sufficient for the current application state; avoids the complexity of a dedicated state management library. Enables efficient view switching without recalculation.
@@ -32,7 +33,10 @@
   * The results statistics are displayed in a 2-column grid (`.results-stats-grid`) with `grid-template-columns: auto auto` and `width: fit-content`, centered within its container. Body padding and main container `max-width` have been adjusted for better large-screen layout. (NEW)
   * Responsive CSS reduces vertical padding/margins in the results area and removes body top/bottom padding on small screens to optimize vertical space. (NEW)
 * **Dependency Management:**
-  * **Pattern:** `date-fns` and `date-fns-tz` are loaded via CDN for runtime date behavior. `gridRenderer.js` includes runtime presence checks and fallback behavior.
+  * **Pattern:** The application has no runtime library dependency; native ES modules provide all date behavior.
+  * **Decision:** `date-fns` and `date-fns-tz` were removed because the CDN-global integration and mixed local/UTC model were unreliable, not because the maintained libraries were defective.
+  * **Tradeoff:** Native helpers are the smallest fit for the current no-build application but increase local calendar-maintenance responsibility.
+  * **Revisit:** Issue #40 evaluates npm module imports with bundling, browser ESM delivery, and Temporal before explicit named-timezone behavior expands.
   * **Pattern:** Dev/test/tooling dependencies are managed via npm lockfile; CI uses `npm ci` for reproducible installs.
   * **Rationale:** Keep runtime lightweight while enforcing deterministic dev/test environments.
 * **Quality Gates:**
@@ -68,7 +72,7 @@
     1. `ui.js` (`renderCurrentView`) determines the view type (`currentView`).
     2. `ui.js` calls the appropriate function in `gridRenderer.js` (e.g., `renderMonthsGrid`), passing `lastCalcData` and the specific `#grid-content-area` element. (UPDATED)
     3. `gridRenderer.js` function clears the *provided element's* (`#grid-content-area`) content. (UPDATED)
-    4. `gridRenderer.js` performs date calculations; Calendar, Month, and Year views use native UTC helpers while Weeks (Age) currently uses `date-fns`.
+    4. `gridRenderer.js` uses shared native UTC helpers for all four views and local-calendar current-period state.
     5. `gridRenderer.js` generates DOM elements (rows, blocks) with correct classes/attributes.
     6. `gridRenderer.js` appends elements to the *provided element* (`#grid-content-area`). (UPDATED)
     7. `gridRenderer.js` sets the `aria-label` on the *parent* (`#life-grid-container`) for overall context. (UPDATED)
@@ -80,9 +84,9 @@
 
 ## 4. Critical Implementation Details
 
-* **`gridRenderer.js` - Age View Week Logic:** Uses `eachWeekOfInterval` + `filter(isBefore)` + `.pop()` (if length 54) to accurately determine the ISO weeks starting within each year of life, ensuring visual consistency (max 53 weeks/row).
+* **`gridRenderer.js` - Age View Week Logic:** Iterates native UTC Monday starts overlapping each age year and trims a natural 54-week span to 53 for visual consistency.
 * **`gridRenderer.js` - Calendar View:** Calculates ISO week-year boundaries directly from UTC date components and correctly handles the 52/53 week variation without browser-timezone drift. Applies `out-of-bounds` styling based on comparison with `firstWeekStartDateUTC` and `estimatedEndDateUTC`.
-* **`gridRenderer.js` - Month View:** Generates exactly `ceil(totalYears * 12)` UTC month starts, classifies the current UTC month, and derives stages and titles from corrected UTC boundaries.
+* **`gridRenderer.js` - Month View:** Generates exactly `ceil(totalYears * 12)` UTC month starts, classifies the browser-local current month, and derives stages and titles from deterministic UTC-encoded boundaries.
 * **`gridRenderer.js` - Year View:** Generates exactly `ceil(totalYears)` UTC birthday anniversaries and classifies state by anniversary intervals. February 29 anniversaries clamp to February 28 in non-leap years.
 * **CSS `calc()` + `aspect-ratio`:** The core mechanism for ensuring Month/Year blocks fill the fixed container width while remaining square. Formulas must be updated in media queries if gaps change.
 * **`js/ui.js` - `handleViewChange()`:** Logic handles clicks on `.view-button` elements, reads `data-view`, and manages `.active`, `aria-selected`, `tabindex`, and tabpanel `aria-labelledby` attributes.

--- a/.kilocode/rules/memory-bank/brief.md
+++ b/.kilocode/rules/memory-bank/brief.md
@@ -30,8 +30,8 @@ This project, **`life-visualized`**, aims to create a web application inspired b
   * Include a disclaimer about the nature of the estimates.
 * **Technical:**
   * Implement using HTML, CSS, and modern vanilla JavaScript (ES Modules).
-  * Utilize the `date-fns` library (v4.1.0+) for reliable date calculations, loaded via CDN.
-  * Ensure consistent and accurate date handling, primarily using UTC.
+  * Use native JavaScript date-only helpers without runtime CDN dependencies.
+  * Treat birthdates as timezone-free calendar dates, use the user's local calendar for “today,” and use UTC-encoded boundaries for deterministic calculations.
   * Employ a modular JavaScript structure (`calculator`, `data`, `gridRenderer`, `ui`, `main`).
   * Implement a responsive design suitable for desktop, tablet, and mobile devices.
   * Maintain clean, well-documented code.

--- a/.kilocode/rules/memory-bank/context.md
+++ b/.kilocode/rules/memory-bank/context.md
@@ -4,7 +4,7 @@
 Keep all visualization and UI state behavior deterministic across browser timezones while maintaining a high-signal test baseline.
 
 ## Current Task
-Fix issues #33 and #34 by making Month and Year rendering independent of browser timezone.
+Complete issue #35 by making age and current-period behavior correct in the user's browser timezone.
 
 ## Recent Changes
 
@@ -14,17 +14,16 @@ Fix issues #33 and #34 by making Month and Year rendering independent of browser
 - Month view now computes month starts, titles, states, and stages directly from UTC components.
 - Year view now computes birthday anniversaries, titles, and states directly from UTC components.
 - Leap-day anniversaries use February 28 in non-leap years.
-- Added deterministic regressions that run Month/Year rendering under UTC, Los Angeles, London, Tokyo, and Auckland settings without local-time `dateFns` helpers.
+- Added shared native date-only helpers and removed runtime `date-fns`/`date-fns-tz` dependencies.
+- Age and present-period state now follow local calendar boundaries.
+- Added deterministic regressions under UTC, Los Angeles, London, Tokyo, and Auckland.
 - Opened:
   - Issue #31 for a future Calendar/Birthday week-alignment toggle.
   - Issue #35 for broader worldwide timezone correctness.
-- Issue #32 is closed; issues #33 and #34 are fixed locally pending merge.
-- Local baseline validated:
-  - `conda run -n base npm run verify` -> 69/69 tests passing
-  - `conda run -n base npm run test:coverage` -> 95.81% statements, 82.62% branches, 100% functions, 97.36% lines
+- Issues #32, #33, and #34 are closed; issue #35 is implemented locally.
 
 ## Next Action
-Commit the Month/Year fixes and documentation updates, then merge and close issues #33 and #34.
+Finish verification and browser checks, then commit and merge the issue #35 branch.
 
 ## Decisions
 - Adopted Node 20 as CI baseline due to `vitest@4` engine requirements.
@@ -36,6 +35,11 @@ Commit the Month/Year fixes and documentation updates, then merge and close issu
 - Compute Calendar ISO boundaries with native UTC helpers instead of local-time `date-fns` functions.
 - Compute Month boundaries and Year birthday anniversaries with native UTC helpers.
 - Treat February 28 as the non-leap-year anniversary for February 29 births.
+- Treat birthdates as timezone-free calendar dates.
+- Use browser-local year/month/day for “today,” age rollover, and present-period state.
+- Encode local today and generated boundaries as UTC dates before arithmetic.
+- Use native JavaScript date helpers with no runtime CDN dependency.
+- Treat the native-helper choice as provisional; issue #40 owns investigation of maintained library integration.
 
 ## Blockers
 None.
@@ -62,8 +66,8 @@ None.
 ## Open Questions/Decisions
 - Should CI include coverage thresholds (`npm run test:coverage`) as an additional gate?
 - Should the project adopt stricter type checking over time (e.g., gradual `checkJs` opt-in per file)?
-- Should the optional `date-fns-tz` CDN integration be repaired, upgraded, or removed in favor of native UTC helpers?
-- How should issue #35 reconcile local-calendar current-period behavior with deterministic UTC-generated boundaries?
+- How should future country-specific actuarial data infer a default location while allowing explicit “what if” selection?
+- Should named-timezone growth use bundled `date-fns`/`date-fns-tz`, browser ESM delivery, Temporal, or a staged combination? Track the decision in issue #40.
 
 ## Learnings & Insights
 

--- a/.kilocode/rules/memory-bank/product.md
+++ b/.kilocode/rules/memory-bank/product.md
@@ -20,7 +20,7 @@ It is **not** intended as a precise predictive tool but rather as a thought-prov
   * **Clarity:** The visualization should be immediately understandable. The grid, colors, and states (past/present/future) should be intuitive. Explanations and keys should be easily accessible when needed. The current view should be clearly indicated.
   * **Simplicity:** The initial interaction should be focused and straightforward (enter details, calculate). Complexity is revealed progressively.
   * **Impact:** The visualization should be striking and encourage contemplation. Placing the grid prominently after results enhances impact.
-  * **Accuracy (within scope):** Calculations should correctly reflect age and use the specified actuarial data. Date handling across timezones/DST must be deterministic; Calendar, Month, and Year boundaries now meet this requirement, while broader local-time correctness remains tracked in issue #35.
+  * **Accuracy (within scope):** Calculations should correctly reflect age and use the specified actuarial data. Age and current-period state follow the user's browser-local calendar, while generated boundaries remain deterministic across timezones and DST.
   * **Responsiveness:** The experience should be seamless across desktop, tablet, and mobile devices.
   * **Transparency:** Explanations for visualization nuances (53-week years, calendar view) and a clear disclaimer about the nature of the estimates are essential.
   * **Visual Cohesion:** Controls and related information should feel integrated with the visualization they affect.
@@ -69,7 +69,7 @@ It is **not** intended as a precise predictive tool but rather as a thought-prov
 * **Fixed Grid Container Width:** Ensures a stable and predictable user experience when switching between views.
 * **Dynamic Block Sizing (Months/Years):** Makes less granular views visually fill the available space effectively.
 * **Clear Disclaimer & Explanations:** Manages user expectations and clarifies visualization nuances.
-* **UTC Date Handling:** Accepted date-only input is normalized to UTC. Calendar, Month, and Year views compute boundaries and titles directly from UTC date components so they do not drift with browser timezone. Leap-day Year anniversaries use February 28 in non-leap years.
+* **Local Calendar + UTC-Encoded Boundaries:** Accepted birthdates are timezone-free calendar values encoded at UTC midnight. User-facing “today,” age rollover, and present-period state follow the browser's local calendar. All generated boundaries use UTC components so they do not drift with browser timezone. Leap-day anniversaries use February 28 in non-leap years.
 * **Progressive Reveal:** Creates a cleaner starting point focused on input.
 * **Consolidated & Collapsible Guide/Key:** Keeps secondary information accessible but visually tidy. Explanation text refined for clarity and user-friendliness.
 * **Integrated & Nested Controls Header:** Creates a strong visual connection between controls and visualization. Tooltips reduce clutter.

--- a/.kilocode/rules/memory-bank/progress.md
+++ b/.kilocode/rules/memory-bank/progress.md
@@ -2,52 +2,43 @@
 
 ## Latest Update (2026-07-28)
 - Status: Active
-- Summary: Issues #33 and #34 are fixed locally with native UTC Month/Year generation and regression coverage.
+- Summary: Worldwide local-calendar correctness from issue #35 is implemented locally.
 
 ## Recent Changes
-- Month rendering corrected in [`js/gridRenderer.js`](js/gridRenderer.js:1):
-  - Native UTC helpers replace `dateFns.startOfMonth`, `addMonths`, comparisons, and formatting.
-  - Exact fractional-lifespan block counts and unique month starts are preserved.
-  - Current-month state and life stages use corrected UTC month boundaries.
-- Year rendering corrected in [`js/gridRenderer.js`](js/gridRenderer.js:1):
-  - Native UTC birthday anniversaries replace local-time `dateFns.addYears`.
-  - Anniversary intervals determine past/present/future state.
-  - February 29 clamps to February 28 in non-leap years.
-- Issue #32 was merged through PR #37 and closed.
-- Issues #33 and #34 remain open until this branch reaches `main`.
+- Added shared native date utilities in `js/dateUtils.js`.
+- Changed current age from UTC-midnight rollover to browser-local-midnight rollover.
+- Changed current week, month, and age-year classification to use the browser's local calendar.
+- Kept birthdates and generated boundaries as deterministic UTC-encoded calendar dates.
+- Replaced Weeks (Age) `date-fns` generation with native ISO-week arithmetic.
+- Removed `date-fns`, `date-fns-tz`, and obsolete browser-global type declarations.
+- Documented that removal addressed the CDN-global integration and mixed date models, not defects in the maintained libraries.
+- Created issue #40 to evaluate properly imported libraries, browser ESM delivery, and Temporal.
+- Stored the resolved browser IANA timezone with successful calculation state.
 
 ## New/Updated Test Files
+- `tests/unit/dateUtils.test.js`
+- `tests/unit/calculator.test.js`
+- `tests/unit/gridRenderer.calendar.test.js`
+- `tests/unit/gridRenderer.edge.test.js`
+- `tests/unit/gridRenderer.failure.test.js`
 - `tests/unit/gridRenderer.months.test.js`
 - `tests/unit/gridRenderer.years.test.js`
-- `tests/unit/gridRenderer.failure.test.js`
 
 ## Completed Tasks
-- Reproduced the Month and Year timezone defects.
-- Removed Month/Year dependence on local-time arithmetic and `date-fns-tz` formatting.
-- Added timezone-invariant regressions for UTC, Los Angeles, London, Tokyo, and Auckland settings.
-- Added exact fractional-lifespan count and unique-boundary checks.
-- Defined and tested leap-day anniversary behavior.
-- Browser-verified both issue reproductions and leap-day titles.
-- Local verification succeeds via `conda run -n base npm run verify` (69/69 tests pass).
+- Defined one date model for local user semantics and deterministic boundaries.
+- Added representative-zone coverage for both sides of UTC.
+- Added local-midnight, UTC-rollover, DST, leap-day, month/year, and ISO-week regressions.
+- Replaced synthetic 54-week mocks with a real age-year boundary.
+- Removed obsolete missing-CDN failure tests and retained meaningful renderer failure handling.
+- Added targeted Weeks (Age), UI local-date, date-helper contract, and real-module integration tests.
+- Full conda verification passes: 13 test files / 87 tests.
+- Coverage passes: 97.96% statements, 87.09% branches, 100% functions, 98.15% lines.
+- Browser verification passes for calculation, all four renderers, present-period markers, console errors, and Start Over reset.
 
 ## Remaining Work / Next Steps
-- Commit and merge the current changes; close issues #33 and #34 after merge.
-- Continue issue #35 for worldwide local-time semantics outside Month/Year generation.
-- Implement issue #31 while keeping Calendar weeks as the default.
-- Decide whether to remove the unavailable `date-fns-tz` browser dependency.
-- Decide whether to add coverage threshold enforcement in CI.
-
-## Test Summary (current)
-- Commands:
-  - `conda run -n base npm run verify`
-  - `conda run -n base npm run test:coverage`
-- Current result summary: 69 tests passing locally (0 failing), 11 test files.
-- Current coverage summary:
-  - Statements: `95.81%`
-  - Branches: `82.62%`
-  - Functions: `100%`
-  - Lines: `97.36%`
+- Commit, open a PR linked to issue #35, and merge after CI.
+- Continue issue #31 and coverage-threshold decisions separately.
 
 ## Notes
-- Month/Year tests deliberately make local-time `dateFns` operations unusable so regressions cannot be hidden by UTC-only mocks.
-- Runtime architecture remains static and CDN-based. Only Weeks (Age) still relies on `date-fns` for boundary generation.
+- Location means browser timezone for date behavior; geolocation is not requested.
+- Future country-specific actuarial data remains separate and should default from location while allowing explicit “what if” selection.

--- a/.kilocode/rules/memory-bank/tech.md
+++ b/.kilocode/rules/memory-bank/tech.md
@@ -8,15 +8,10 @@
 
 ## 2. Key Libraries & Dependencies
 
-* **Runtime CDN dependencies:**
-  * **`date-fns` v4.1.0:**
-  * **Usage:** Used by the Weeks (Age) renderer for week generation and comparisons. Calendar, Month, and Year boundaries use native UTC helpers.
-  * **Integration:** Loaded via CDN (`https://cdn.jsdelivr.net/npm/date-fns@4.1.0/cdn.min.js`) in `index.html`. Accessed globally via the `dateFns` object.
-  * **Constraint:** The application relies on this specific version (or compatible 4.x) being available globally. `gridRenderer.js` includes a basic check for its presence.
-  * **`date-fns-tz` v1.3.7:**
-  * **Usage:** Intended as an optional timezone-aware formatting helper. Calendar, Month, and Year views no longer depend on it and format UTC dates directly.
-  * **Integration:** Loaded via CDN (`https://cdn.jsdelivr.net/npm/date-fns-tz@1.3.7/dist/date-fns-tz.min.js`) in `index.html`. Accessed globally via `dateFnsTz`.
-  * **Known runtime state:** The current CDN script does not expose `dateFnsTz` in the audited browser runtime, so remaining renderers use their core `date-fns` fallback paths.
+* **Runtime dependencies:** None.
+  * Native JavaScript and `Intl.DateTimeFormat` provide date-only, ISO-week, and IANA timezone behavior.
+  * `js/dateUtils.js` centralizes local-calendar conversion and deterministic UTC arithmetic.
+  * This is a provisional architecture choice for the static no-build runtime. Issue #40 tracks whether maintained date libraries should return through module imports and a documented build strategy.
 
 * **Dev/test dependencies (npm):**
   * `vitest` `^4.1.1`
@@ -35,7 +30,7 @@
 ## 4. Technical Constraints
 
 * **Client-Side Only:** No backend infrastructure. All data (`data.js`) and logic reside and execute within the browser.
-* **CDN Dependency:** Relies on the `date-fns` CDN being available and accessible to the user. Offline usage is not possible without local hosting of the library.
+* **No Build/Runtime Dependency:** The application runs from static first-party files. A local HTTP server is still required for ES modules.
 * **Browser Compatibility:** Primarily targets modern evergreen browsers. Compatibility with older browsers (e.g., IE11) is not a goal and likely broken due to ES6+ features and modern CSS.
 
 ## 5. Tool Usage Patterns
@@ -47,18 +42,18 @@
   * Local coverage: `npm run test:coverage`
   * CI: `.github/workflows/ci.yml` runs `npm ci`, `npm run lint`, `npm run typecheck`, `npm run test:run`
 
-## 6. Current Test/Coverage Baseline (2026-07-27)
+## 6. Current Test/Coverage Baseline (2026-07-28)
 
-* Unit test files: `11`
-* Passing tests: `69`
+* Unit test files: `13`
+* Passing tests: `87`
 * Coverage:
-  * Statements: `95.81%`
-  * Branches: `82.62%`
+  * Statements: `97.96%`
+  * Branches: `87.09%`
   * Functions: `100%`
-  * Lines: `97.36%`
+  * Lines: `98.15%`
 ## 7. Additional Notes from Historical Context
 
 * The project has undergone multiple iterations of UX refinement focusing on clarity, simplicity, and accessibility.
 * Accessibility improvements include ARIA roles, keyboard navigation, and focus management.
 * The CSS uses modern layout techniques and responsive design to ensure usability across devices.
-* The project is designed to be lightweight and dependency-minimal, relying primarily on vanilla JavaScript and a single date library.
+* The project is designed to be lightweight and uses no third-party runtime JavaScript libraries.

--- a/.kilocode/rules/memory-bank/tests-plans-by-module.md
+++ b/.kilocode/rules/memory-bank/tests-plans-by-module.md
@@ -7,7 +7,7 @@ Brief: Separate, focused test plans for each core module to keep the memory bank
 - Primary functions: [`js/calculator.js`](js/calculator.js:1)
 - Priority: High
 - Tests:
-  1. Age calculation edge cases: birthday passed, birthday not reached, leap-day handling, future birth date.
+  1. Age calculation edge cases: birthday passed, birthday not reached, local-midnight rollover, leap-day handling, future birth date.
   2. getRemainingExpectancy: exact bracket matches, mid-bracket ages, very large ages (fallback to highest bracket), invalid sex -> throws.
   3. Invalid data handling: non-numeric strings, Infinity, NaN -> throws; missing sex key / empty bracket map -> returns null.
 - Test notes:
@@ -36,13 +36,13 @@ Brief: Separate, focused test plans for each core module to keep the memory bank
 - Priority: Medium-High
 - Tests:
   1. Helpers: `getLifeStageKey` boundary checks; `calculateAgeAtDate` correctness across UTC dates.
-  2. `renderAgeGrid`: enforce max 53 weeks when `eachWeekOfInterval` yields 54; confirm past/present/future classes.
+  2. `renderAgeGrid`: enforce max 53 weeks for a natural 54-week span; confirm past/present/future classes.
   3. `renderCalendarGrid`: native UTC ISO week/year handling for known 52/53-week years, unique Monday starts, fractional lifespan endpoints, out-of-bounds weeks, and per-week age/stage correctness.
   4. `renderMonthsGrid`: exact fractional-lifespan counts, unique native UTC month starts, state classification, and life-stage assignment across representative timezones.
   5. `renderYearsGrid`: exact fractional-lifespan counts, native UTC anniversaries, decade rows, anniversary-based state classes, and February 29 clamping.
-  6. Failure modes: missing `dateFns` -> DOM shows error-message; missing DOM element param -> no throw.
-  7. Timezone regression: Calendar, Month, and Year boundaries must produce identical counts/titles without relying on UTC-only mocks of local-time `dateFns` functions.
-- Test notes: Use JSDOM; mock only the remaining global `dateFns` functions required by each renderer. Calendar, Month, and Year tests should exercise production UTC helpers directly.
+  6. Runtime/failure modes: every renderer works without external globals; missing DOM element is safe; unexpected date behavior shows an error.
+  7. Timezone regression: generated boundaries remain deterministic while current week/month/year follows the local calendar across UTC rollover.
+- Test notes: Use JSDOM and production native date helpers. Test representative timezone settings directly.
 - Estimated effort: 6–12 tests
 
 ## js/ui.js
@@ -76,17 +76,18 @@ Brief: Separate, focused test plans for each core module to keep the memory bank
 - Scenarios:
   1. Full success flow: valid inputs -> mocked expectancy -> results area populated, grid rendered into [`#grid-content-area`](index.html:118), start-over visible.
   2. Error flow: invalid birthdate -> error shown; grid remains hidden; `lastCalcData` unchanged.
-- Test notes: Use real modules but mock `dateFns` and `lifeExpectancyData` as needed; run in JSDOM.
+  3. Real timezone flow: production UI, calculator, data, date utilities, and renderer calculate and render together under a representative browser timezone.
+- Test notes: Use real modules and mock `lifeExpectancyData` only where needed; run in JSDOM.
 - Estimated effort: 3–5 tests
 
-## Current Status Snapshot (2026-07-27)
-- Unit test files: `11`
-- Tests passing: `69`
+## Current Status Snapshot (2026-07-28)
+- Unit test files: `13`
+- Tests passing: `87`
 - Coverage:
-  - Statements: `95.81%`
-  - Branches: `82.62%`
+  - Statements: `97.96%`
+  - Branches: `87.09%`
   - Functions: `100%`
-  - Lines: `97.36%`
+  - Lines: `98.15%`
 - Known residual branch gaps are concentrated in defensive renderer branches that are difficult to reach without brittle synthetic mocks.
 
 ## Implementation & Best Practices
@@ -94,7 +95,7 @@ Brief: Separate, focused test plans for each core module to keep the memory bank
 - Use `vi.useFakeTimers()` and `vi.setSystemTime()` for deterministic date tests.
 - Use `vi.resetModules()` and `vi.mock()` to isolate module imports and provide deterministic data fixtures.
 - Avoid runtime mutation helpers embedded in production modules. Prefer supplying test fixtures via explicit `dataOverride`, `vi.mock('../../js/data.js')`, or mocking imported calculator functions when isolating UI code.
-- For renderer tests that rely on date calculations, mock only the specific `date-fns` functions used and set `global.dateFns` to a minimal deterministic shim where needed.
+- For renderer tests, exercise `js/dateUtils.js` production behavior rather than duplicating calendar logic in mocks.
 - Create/teardown DOM fixtures per test to avoid state leakage.
 - Recommended order: start with calculator and data tests (highest priority), then grid renderer helpers and edge cases, then ui and integration tests.
 

--- a/.kilocode/rules/memory-bank/tests-plans.md
+++ b/.kilocode/rules/memory-bank/tests-plans.md
@@ -7,10 +7,10 @@ Brief summary: This file contains separated plans for unit testing each core mod
 - Primary functions: [`js/calculator.js`](js/calculator.js:1)
 - Priority: High
 - Tests:
-  1. Age calculation edge cases: birthday passed, birthday not reached, leap-day handling, future birth date.
+  1. Age calculation edge cases: birthday passed, birthday not reached, local-midnight rollover, leap-day handling, future birth date.
   2. getRemainingExpectancy: exact bracket matches, mid-bracket ages, very large ages, unknown sex -> null.
   3. Invalid data handling: non-numeric strings, Infinity, NaN, missing sex keys -> returns null.
-- Test notes: Freeze time with vi.useFakeTimers(); mock [`js/data.js`](js/data.js:1) via vi.mock for specific values.
+- Test notes: Freeze time with vi.useFakeTimers(); vary `process.env.TZ` for local-midnight regressions; pass explicit data overrides for expectancy fixtures.
 - Estimated effort: 3–5 test groups (~8–12 test cases)
 
 ## js/data.js
@@ -31,12 +31,13 @@ Brief summary: This file contains separated plans for unit testing each core mod
 - Priority: Medium-High
 - Tests:
   1. Helper functions: `getLifeStageKey` boundary checks; `calculateAgeAtDate` date cases.
-  2. renderAgeGrid: enforce max 53 weeks when `eachWeekOfInterval` returns 54 (edge test exists).
+  2. renderAgeGrid: enforce max 53 weeks for a natural 54-week age-year span.
   3. renderCalendarGrid: native UTC ISO boundaries for known 52/53-week years, unique Monday starts, fractional lifespan endpoints, out-of-bounds weeks, and present/past/future classification.
   4. renderMonthsGrid: exact fractional-lifespan counts, unique native UTC month boundaries, state classification, and life-stage assignment across representative timezones.
   5. renderYearsGrid: exact fractional-lifespan counts, native UTC anniversaries, decade rows, anniversary-based state classes, and explicit leap-day behavior.
-  6. Failure modes: missing `dateFns` -> renderer writes error message; missing DOM element param.
-- Test notes: Use JSDOM. Month/Year tests should poison local-time `dateFns` functions so production UTC helpers are exercised directly.
+  6. Runtime/failure modes: all views render without external globals; missing DOM element is safe; unexpected date failure writes an error.
+  7. Current-period state follows local week/month/year boundaries across UTC rollover.
+- Test notes: Use JSDOM and production native date helpers. Vary `process.env.TZ` only where local-calendar state is under test.
 - Estimated effort: 6–10 test cases
 
 ## js/ui.js
@@ -67,7 +68,8 @@ Brief summary: This file contains separated plans for unit testing each core mod
 - Scenarios:
   1. Full flow: valid inputs -> mocked expectancy -> results area populated, grid rendered, start-over visible.
   2. Error flow: invalid birthdate -> error shown; grid remains hidden.
-- Test notes: Use real modules but mock `dateFns` as needed; run in JSDOM environment.
+  3. Real timezone flow: production UI, calculator, data, date utilities, and renderer complete a calculation under a representative browser timezone.
+- Test notes: Use real modules with JSDOM; mock calculator/data boundaries only where isolation requires it.
 - Estimated effort: 3–4 tests
 
 ## Implementation Guidance (applies to all modules)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Many people have difficulty grasping the finite nature of their time, myself inc
 AI assistance was used to:
 
 * Rapidly **prototype** HTML, CSS, and JavaScript.
-* **Explain** core concepts and library usage (e.g., `date-fns`).
+* **Explain** core concepts and date-handling choices.
 * **Generate** boilerplate code and **suggest** refinements.
 * **Troubleshoot** and **aid** in initial documentation, including this README.
 * **Simulate** a team environment by interacting with defined developer, product, and UX personas to **inform** decisions throughout the development process.
@@ -36,7 +36,7 @@ This collaborative approach enabled the creation of this MVP, serving as both a 
 * **Visualization & Grid:**
   * Renders lifespan as a responsive grid of blocks.
   * Multiple Views:
-    * Weeks (arranged by Age Year)
+    * Weeks (arranged by Age Year with deterministic native date arithmetic)
     * Weeks (arranged by ISO Calendar Year with timezone-independent 52/53-week handling)
     * Months (arranged by Age Year with timezone-independent UTC boundaries)
     * Years (arranged by Decade with timezone-independent UTC anniversaries)
@@ -78,7 +78,7 @@ This collaborative approach enabled the creation of this MVP, serving as both a 
 ## Technology Stack
 
 * **Frontend:** HTML5, CSS3 (including Flexbox, CSS Variables, `calc()`, `aspect-ratio`), Vanilla JavaScript (ES6+ Modules)
-* **Core Dependencies:** `date-fns` v4.1.0 and optional `date-fns-tz` v1.3.7 are loaded via CDN. Calendar, Month, and Year date boundaries use native UTC helpers; the Weeks (Age) renderer continues to use `date-fns`. These libraries are used under the MIT License.
+* **Runtime Dependencies:** None. Date-only and ISO-week calculations use native JavaScript helpers. User-facing age and current-period state follow the browser's local calendar while stored boundaries remain deterministic UTC-encoded dates.
 * **Dev Tooling:** Vitest, JSDOM, c8, ESLint (flat config), and TypeScript (`tsc --noEmit` for project typecheck gate).
 * **Development:** Requires a simple local HTTP server (due to ES Modules). No build process currently.
 

--- a/docs/2026-07-28-changes.md
+++ b/docs/2026-07-28-changes.md
@@ -27,5 +27,36 @@ Summary:
 
 Follow-up:
 
-- Issue #35 continues broader worldwide local-time correctness work outside Month/Year boundary generation.
-- Weeks (Age) still uses local-time `date-fns` operations and remains a follow-up risk.
+- Issue #35 implementation:
+  - Added `js/dateUtils.js` as the shared date-only model.
+  - Age now changes at midnight in the browser's local timezone.
+  - Present week, month, and age-year state now follows the browser's local calendar.
+  - Replaced the remaining Weeks (Age) `date-fns` operations with native UTC ISO-week generation.
+  - Removed the `date-fns` and `date-fns-tz` CDN scripts and obsolete global declarations.
+  - Made the browser's resolved IANA timezone available in successful calculation state.
+  - Added local-midnight, UTC-rollover, DST, leap-day, month/year rollover, and ISO 52/53-week regressions across representative timezones.
+
+Current date model:
+
+- Birthdates are timezone-free calendar dates encoded at UTC midnight.
+- User-facing “today” and current-period state use the browser's local calendar date.
+- Generated grid boundaries use UTC components for deterministic output.
+
+Dependency decision:
+
+- `date-fns` and `date-fns-tz` were not removed because the libraries are defective.
+- The previous CDN-global integration was unreliable, and local-time library operations were mixed with UTC-encoded date-only values.
+- Native helpers were the smallest focused fix for the current static, no-build architecture and removed the external runtime dependency.
+- This choice increases local maintenance responsibility and is intentionally revisitable.
+- Issue [#40](https://github.com/jordanhom/life-visualized/issues/40) tracks investigation of properly imported maintained libraries, ESM delivery, and Temporal.
+- See [`docs/dateUtils.md`](docs/dateUtils.md:1) for the full decision and tradeoffs.
+
+Issue #35 validation:
+
+- `conda run -n base npm run verify`: 13 test files, 87 tests passing.
+- `conda run -n base npm run test:coverage`: 97.96% statements, 87.09% branches, 100% functions, 98.15% lines.
+- Additional high-value coverage verifies Weeks (Age) local rollover, UI date validation on both sides of UTC, native-helper migration contracts, and the real UI-to-renderer module graph.
+- Browser verification in the Pacific-time runtime:
+  - Calculation completed without CDN or console errors.
+  - All four views rendered with exactly one present-period block.
+  - Start Over restored empty inputs, hidden results/grid, disabled Calculate, and Weeks (Age).

--- a/docs/calculator.md
+++ b/docs/calculator.md
@@ -9,10 +9,11 @@ Location
 - [`js/calculator.js`](js/calculator.js:1)
 
 Public API (current)
-- calculateCurrentAge(birthDate: Date): number
-  - Returns completed years based on the current UTC date/time.
-  - Throws Error on invalid input (non-Date or invalid Date).
-  - Uses UTC getters (getUTCFullYear/getUTCMonth/getUTCDate) to avoid timezone/DST inconsistencies.
+- calculateCurrentAge(birthDate: Date, currentDateUTC?: Date): number
+  - Returns completed years based on the browser's local calendar date.
+  - Accepts an optional UTC-encoded current calendar date for deterministic callers and tests.
+  - Throws Error when either date is invalid.
+  - Uses shared UTC date-only arithmetic after local today is encoded by `dateUtils.js`.
 - getRemainingExpectancy(age: number, sex: 'male'|'female', dataOverride?: object|null): Promise<number|null>
   - Asynchronously reads `lifeExpectancyData` and returns a numeric estimate.
   - Optional `dataOverride` supports deterministic tests without mutable module state.
@@ -21,9 +22,11 @@ Public API (current)
   - Returns `null` in cases where the sex data is missing or the sex-specific dataset is empty.
 
 Important behaviors and implementation notes
-- UTC-based age calculation:
-  - `calculateCurrentAge` intentionally uses UTC-based Date getters to ensure deterministic results across timezones and when tests freeze system time.
-  - For testing determinism the module's tests inject a frozen system clock; callers may pass a deterministic Date in tests by mocking time.
+- Local-calendar age calculation:
+  - A birthdate remains a timezone-free calendar date encoded at UTC midnight.
+  - The current instant is converted to the browser's local year/month/day before completed years are calculated.
+  - Age changes at local midnight rather than UTC midnight.
+  - February 29 anniversaries use February 28 in non-leap years, matching Year-view boundaries.
 
 - Bracket lookup and fallbacks:
   - The renderer uses numeric string keys in `lifeExpectancyData` (e.g., `'0'`, `'10'`, `'20'`, ...).
@@ -50,7 +53,7 @@ Error policy and contracts
 Testing notes (updated)
 - `calculateCurrentAge` tests:
   - Leap-day birthdays (ensure correct before/after logic).
-  - Boundary moments (one second before UTC birthday vs exactly at UTC midnight).
+  - Boundary moments immediately before and at local midnight in representative timezones.
   - Future birth dates -> returns 0 (the function clamps to >= 0).
   - Invalid birthDate -> throws.
 - `getRemainingExpectancy` tests:
@@ -63,7 +66,7 @@ Testing notes (updated)
   - Deterministic overrides: pass `dataOverride` directly in test calls.
 
 Examples
-- calculateCurrentAge(new Date('1990-06-10T00:00:00Z')) // uses UTC date parts
+- calculateCurrentAge(new Date('1990-06-10T00:00:00Z')) // uses the browser's local today
 - await getRemainingExpectancy(35, 'female') // returns numeric remaining years or null
 
 Future improvements (non-blocking)
@@ -76,5 +79,6 @@ Future improvements (non-blocking)
 
 References
 - Data source: [`js/data.js`](js/data.js:1)
+- Date model and dependency decision: [`docs/dateUtils.md`](docs/dateUtils.md:1)
 - Module: [`js/calculator.js`](js/calculator.js:1)
 - Tests: [`tests/unit/calculator.test.js`](tests/unit/calculator.test.js:1)

--- a/docs/dateUtils.md
+++ b/docs/dateUtils.md
@@ -1,0 +1,43 @@
+# Date Utilities (`js/dateUtils.js`)
+
+Purpose
+Provide one date-only model for age calculation and grid rendering:
+- Treat birthdates as timezone-free calendar dates.
+- Derive user-facing “today” from the browser's local calendar.
+- Encode calendar dates at UTC midnight before deterministic arithmetic.
+- Generate month, year, and ISO-week boundaries without timezone drift.
+
+Location
+- [`js/dateUtils.js`](js/dateUtils.js:1)
+
+Why native helpers replaced the date libraries
+- `date-fns` and `date-fns-tz` are maintained, tested libraries; the libraries themselves were not identified as defective.
+- The previous application integration loaded them as CDN browser globals rather than npm modules.
+- The expected `date-fns-tz` global was unavailable in the audited browser runtime.
+- Local-time `date-fns` operations were mixed with UTC-encoded birthdates, which caused the timezone defects tracked in issues #32-#35.
+- Correcting the integration with npm module imports would introduce a bundling/build decision beyond the focused behavior fix.
+- The current required operations are narrow enough to implement directly with native UTC methods and protect with representative timezone and boundary tests.
+- Removing CDN scripts also removes an external runtime availability requirement.
+
+Tradeoff
+- Native helpers reduce runtime and build complexity but move calendar-maintenance responsibility into this repository.
+- Maintained libraries become more valuable as requirements expand to explicit named-timezone conversion, historical timezone rules, or user-selectable “what if” locations.
+- The current implementation is a pragmatic choice for the static no-build application, not a permanent rejection of date libraries.
+
+Current contract
+- `getLocalDateUTC` reads local year/month/day from an instant and returns the same calendar date encoded at UTC midnight.
+- `getBrowserTimeZone` returns the browser's resolved IANA timezone, with `UTC` as a defensive fallback.
+- UTC helpers perform month-end clamping, February 29 anniversary clamping, formatting, and ISO-week calculations.
+- Age changes at browser-local midnight.
+- Present week, month, and age-year state follows the browser-local calendar.
+- Generated titles and boundaries remain deterministic UTC-encoded dates.
+
+Revisit criteria
+- GitHub issue [#40](https://github.com/jordanhom/life-visualized/issues/40) tracks investigation of maintained libraries and Temporal.
+- Any migration must avoid CDN globals, preserve the issue #35 date model, and pass the existing timezone regression suite.
+- If libraries are adopted, prefer npm module imports with a documented bundling strategy.
+
+References
+- Calculator: [`js/calculator.js`](js/calculator.js:1)
+- Renderer: [`js/gridRenderer.js`](js/gridRenderer.js:1)
+- Current change summary: [`docs/2026-07-28-changes.md`](docs/2026-07-28-changes.md:1)

--- a/docs/gridRenderer.md
+++ b/docs/gridRenderer.md
@@ -18,7 +18,7 @@ Public API
 
 Key internal concepts
 - LIFE_STAGES array and getLifeStageKey(age)
-- UTC-normalized date handling; Calendar, Month, and Year boundaries use native UTC helpers while Weeks (Age) still relies on global `dateFns` v4.x
+- UTC-normalized date-only handling through shared native helpers in `js/dateUtils.js`
 - UTC month/year arithmetic and formatting through `addMonthsUTC`, `addYearsUTC`, `startOfMonthUTC`, and `formatUTCDate`
 - Calendar helpers `startOfISOWeekUTC`, `getISOWeekYearUTC`, `getISOWeekStartUTC`, and `getISOWeeksInYearUTC`
 - DocumentFragment usage for performance
@@ -32,6 +32,7 @@ Behavioral details & edge cases
 - Weeks-by-Age:
   - Generates weeks overlapping each age-year interval.
   - Filters weeks so their start is strictly before the next birthday; trims 54→53 weeks if encountered.
+  - Uses native UTC ISO-week generation with no external runtime library.
   - Titles include week start date and indication of current week.
 - Weeks-by-Calendar:
   - Iterates ISO years between birth and estimated end.
@@ -50,6 +51,7 @@ Behavioral details & edge cases
 State classification
 - Each block gets a `stage-{key}` class via `getLifeStageKey(age)`.
 - Each block gets one of: `past`, `present`, `future`, or `out-of-bounds` on calendar view.
+- The present week, month, or age-year is selected from the user's local calendar date, then compared against UTC-encoded boundaries.
 
 Refactor considerations
 - LIFE_STAGES and getLifeStageKey should be extracted into `js/gridUtils.js` to be shared across renderers.
@@ -63,7 +65,7 @@ Refactor considerations
 Testing guidance
 - Create `tests/grid-renderer-smoke.html` that imports the module and calls each renderer with deterministic inputs.
 - Validate known 52/53-week ISO years, unique block titles, UTC Monday starts, Month/Year boundaries, leap-day anniversaries, and fractional lifespan counts.
-- Ensure Month/Year tests exercise production UTC helpers and remain identical under representative browser timezone settings.
+- Ensure current-period tests cover local midnight and UTC rollover under representative browser timezone settings.
 
 Performance notes
 - Already uses DocumentFragment; maintain this.
@@ -75,4 +77,5 @@ Accessibility & ARIA
 
 References
 - UI orchestration: [`js/ui.js`](js/ui.js:1)
+- Date model and dependency decision: [`docs/dateUtils.md`](docs/dateUtils.md:1)
 - API sketch: [`docs/gridUtils-api.md`](docs/gridUtils-api.md:1)

--- a/docs/gridUtils-api.md
+++ b/docs/gridUtils-api.md
@@ -6,7 +6,7 @@ Provide a small, focused utilities module to centralize common grid logic curren
 Goals
 - Extract pure date and block-generation helpers.
 - Provide a small block element factory that preserves existing CSS/class conventions.
-- Keep native UTC and remaining Weeks (Age) `date-fns` assumptions explicit.
+- Reuse native UTC date-only helpers from `js/dateUtils.js`.
 - Maintain ARIA/title metadata and DocumentFragment-friendly rendering.
 
 Design Principles
@@ -71,7 +71,7 @@ Migration plan (incremental)
 Performance & Accessibility notes
 - Keep using DocumentFragment in renderRow to avoid layout thrash.
 - makeBlockElement should set title attributes and preserve `role`/`aria-*` as needed.
-- Keep UTC semantics explicit and isolate the remaining Weeks (Age) `date-fns` calls.
+- Keep local-calendar versus UTC-encoded boundary semantics explicit.
 - Preserve existing CSS class names (stage-{key}, present/past/future/out-of-bounds) to avoid large stylesheet changes.
 
 Next actions

--- a/docs/gridUtils.md
+++ b/docs/gridUtils.md
@@ -39,7 +39,7 @@ Types & constants to export
 
 Design notes
 - Pure helpers whenever possible; allow injection of `nowUTC` for deterministic tests.
-- Isolate the remaining Weeks (Age) `date-fns` usage while preserving native UTC helpers for other views.
+- Build on the shared native UTC helpers now located in `js/dateUtils.js`.
 - Preserve existing CSS class names and titles to avoid stylesheet churn.
 - Keep DOM factories minimal and side-effect free beyond element creation.
 
@@ -64,10 +64,10 @@ Testing & harness
 - Expose helpers on `window` in `tests/gridUtils.test.html` for rapid console assertions.
 
 Migration path (incremental)
-1. Add `js/gridUtils.js` exporting pure helpers and constants.
-2. Extract the existing native UTC Month/Year generation from [`js/gridRenderer.js`](js/gridRenderer.js:1) without changing behavior.
+1. Add `js/gridUtils.js` exporting pure grid helpers and constants.
+2. Reuse `js/dateUtils.js` rather than duplicating date-only and ISO-week arithmetic.
 3. Smoke test via the browser (`index.html`) and `tests/grid-renderer-smoke.html`.
-4. Refactor Weeks-Age and Weeks-Calendar, verifying after each change.
+4. Extract Weeks-Age and Weeks-Calendar grid generation, verifying after each change.
 5. Remove duplication from `js/gridRenderer.js` and update docs.
 
 Performance & accessibility notes

--- a/docs/main.md
+++ b/docs/main.md
@@ -1,7 +1,7 @@
 # Main Module (`js/main.js`)
 
 Purpose
-The smallest entry point for the application. Responsible for bootstrapping UI initialization and performing any global sanity checks on load.
+The smallest entry point for the application. Responsible for bootstrapping UI initialization.
 
 Location
 - [`js/main.js`](js/main.js:1)
@@ -9,14 +9,13 @@ Location
 What it should do
 - Import and call the public initialization function exported by the UI layer.
 - Ensure the DOM is ready before calling into UI.
-- Optionally log startup diagnostics (e.g., presence of `date-fns`).
 
 Public behaviour / API
 - No exported API (runs on script import).
 - Side-effect: calls [`setupEventListeners()`](js/ui.js:1) from the UI module.
 
 Side-effects & requirements
-- Must be loaded after the `date-fns` CDN script in [`index.html`](index.html:1) to allow renderers to rely on `dateFns`.
+- Loads as a native ES module with no runtime CDN dependency.
 - Minimal logic — keep to DOM-ready check + one line to initialize the app.
 
 Tests / verification

--- a/docs/memory-bank.md
+++ b/docs/memory-bank.md
@@ -2,6 +2,15 @@
 
 ## 2026-07-28
 
+- Implemented worldwide local-calendar correctness tracked in issue #35:
+  - Age changes at browser-local midnight.
+  - Current week, month, and age-year state follows the browser's local calendar.
+  - Birthdates and generated boundaries remain deterministic UTC-encoded dates.
+  - Added shared native helpers in `js/dateUtils.js`.
+  - Removed the `date-fns` and `date-fns-tz` CDN runtime dependencies.
+  - Added timezone, DST, leap-day, UTC-rollover, and ISO-week regression coverage.
+  - Verification: 13 files / 87 tests; 97.96% statements, 87.09% branches, 100% functions, 98.15% lines.
+  - Added Weeks (Age) rollover, UI local-date validation, date-helper contract, and real-module integration coverage.
 - Fixed Month and Year timezone drift tracked in issues #33 and #34:
   - Native UTC helpers now generate Month boundaries and Year birthday anniversaries.
   - Month/Year titles no longer depend on `date-fns-tz` or local-time formatting.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -19,7 +19,7 @@ Key responsibilities
 
 Important internal functions (testable)
 - areInputsValid()
-- getTodayUTC()
+- getLocalDateUTC() (imported from `dateUtils.js`)
 - formatDateInputValue(date)
 - parseBirthdateUTC(value)
 - updateButtonState()
@@ -43,7 +43,8 @@ DOM contracts
 Integration points
 - Calls renderers from [`js/gridRenderer.js`](js/gridRenderer.js:1).
 - Uses calculation functions from [`js/calculator.js`](js/calculator.js:1).
-- Expects `date-fns` to be available globally for renderer behavior.
+- Records the browser's resolved IANA timezone with successful calculation state for diagnostics and future location-aware features.
+- Has no external runtime date-library requirement.
 
 Testing guidance
 - Unit-ish browser harness: simulate form input and submit, assert `#results-area` text and that `#grid-content-area` has children.

--- a/index.html
+++ b/index.html
@@ -134,12 +134,6 @@
 
     </div> <!-- End .container -->
 
-    <!-- External Libraries -->
-    <!-- date-fns v4.1.0 is required by gridRenderer.js and ui.js -->
-    <script src="https://cdn.jsdelivr.net/npm/date-fns@4.1.0/cdn.min.js"></script>
-    <!-- date-fns-tz provides timezone-aware helpers used by gridRenderer.js -->
-    <script src="https://cdn.jsdelivr.net/npm/date-fns-tz@1.3.7/dist/date-fns-tz.min.js"></script>
-
     <!-- Main Application Script -->
     <!-- Loaded as a module to enable import/export syntax -->
     <script type="module" src="js/main.js"></script>

--- a/js/calculator.js
+++ b/js/calculator.js
@@ -10,39 +10,23 @@
  * Relies on `lifeExpectancyData` imported from `data.js`.
  */
 
+import { calculateAgeAtDateUTC, getLocalDateUTC } from './dateUtils.js';
+
 /**
- * Calculates current age in whole years using UTC components.
- *
- * NOTE: The project uses UTC-normalized dates across modules to avoid
- * timezone and DST-related inconsistencies. Tests freeze system time
- * (vitest fake timers), and using UTC getters ensures behavior is
- * deterministic regardless of the machine's local timezone.
- *
+ * Calculates current age from UTC-encoded calendar dates.
  * @param {Date} birthDate - UTC-normalized birth date (Date).
+ * @param {Date} [currentDateUTC=getLocalDateUTC()] - UTC-encoded local calendar date.
  * @returns {number} Age in completed years (>= 0).
  */
-function calculateCurrentAge(birthDate) {
-    // Validate input
+function calculateCurrentAge(birthDate, currentDateUTC = getLocalDateUTC()) {
     if (!(birthDate instanceof Date) || Number.isNaN(birthDate.getTime())) {
         throw new Error('Invalid birthDate provided to calculateCurrentAge');
     }
-    
-    // Use UTC-based components to avoid timezone/DST surprises and to match
-    // the rest of the codebase (gridRenderer uses UTC date-fns helpers).
-    const now = new Date();
-    let age = now.getUTCFullYear() - birthDate.getUTCFullYear();
-    const monthDiff = now.getUTCMonth() - birthDate.getUTCMonth();
-
-    // Decrement age if the current UTC date is before the birthday in the current year.
-    // Using UTC dates prevents off-by-one results when local timezone shifts the local date
-    // relative to the intended UTC midnight stored in birthDate.
-    if (monthDiff < 0 || (monthDiff === 0 && now.getUTCDate() < birthDate.getUTCDate())) {
-        age--;
+    if (!(currentDateUTC instanceof Date) || Number.isNaN(currentDateUTC.getTime())) {
+        throw new Error('Invalid currentDateUTC provided to calculateCurrentAge');
     }
 
-    // Ensure non-negative age for future birth dates; caller (ui.js) should validate input,
-    // but this guard keeps the function robust and easy to test.
-    return Math.max(0, age);
+    return calculateAgeAtDateUTC(currentDateUTC, birthDate);
 }
 
 /**

--- a/js/dateUtils.js
+++ b/js/dateUtils.js
@@ -1,0 +1,144 @@
+// @ts-check
+
+/**
+ * Encodes a local calendar date as UTC midnight for deterministic date-only arithmetic.
+ * @param {Date} [instant=new Date()] - Instant whose local calendar date should be encoded.
+ * @returns {Date}
+ */
+function getLocalDateUTC(instant = new Date()) {
+    return new Date(Date.UTC(
+        instant.getFullYear(),
+        instant.getMonth(),
+        instant.getDate()
+    ));
+}
+
+/**
+ * Returns the browser's resolved IANA timezone for diagnostics.
+ * @returns {string}
+ */
+function getBrowserTimeZone() {
+    try {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    } catch {
+        return 'UTC';
+    }
+}
+
+/**
+ * Adds whole calendar months using UTC components and clamps to the target month end.
+ * @param {Date} date
+ * @param {number} months
+ * @returns {Date}
+ */
+function addMonthsUTC(date, months) {
+    const targetMonthIndex = date.getUTCMonth() + months;
+    const targetYear = date.getUTCFullYear() + Math.floor(targetMonthIndex / 12);
+    const targetMonth = ((targetMonthIndex % 12) + 12) % 12;
+    const lastDayOfTargetMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+    return new Date(Date.UTC(
+        targetYear,
+        targetMonth,
+        Math.min(date.getUTCDate(), lastDayOfTargetMonth)
+    ));
+}
+
+/**
+ * Adds years with month precision. February 29 clamps to February 28 in non-leap years.
+ * @param {Date} date
+ * @param {number} years
+ * @returns {Date}
+ */
+function addYearsUTC(date, years) {
+    return addMonthsUTC(date, Math.trunc(years * 12));
+}
+
+/**
+ * @param {Date} date
+ * @returns {Date}
+ */
+function startOfMonthUTC(date) {
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+/**
+ * @param {Date} date
+ * @returns {Date}
+ */
+function startOfISOWeekUTC(date) {
+    const weekStart = new Date(Date.UTC(
+        date.getUTCFullYear(),
+        date.getUTCMonth(),
+        date.getUTCDate()
+    ));
+    const daysSinceMonday = (weekStart.getUTCDay() + 6) % 7;
+    weekStart.setUTCDate(weekStart.getUTCDate() - daysSinceMonday);
+    return weekStart;
+}
+
+/**
+ * @param {Date} date
+ * @returns {number}
+ */
+function getISOWeekYearUTC(date) {
+    const thursday = startOfISOWeekUTC(date);
+    thursday.setUTCDate(thursday.getUTCDate() + 3);
+    return thursday.getUTCFullYear();
+}
+
+/**
+ * @param {number} isoYear
+ * @param {number} [weekNumber=1]
+ * @returns {Date}
+ */
+function getISOWeekStartUTC(isoYear, weekNumber = 1) {
+    const firstWeekStart = startOfISOWeekUTC(new Date(Date.UTC(isoYear, 0, 4)));
+    firstWeekStart.setUTCDate(firstWeekStart.getUTCDate() + ((weekNumber - 1) * 7));
+    return firstWeekStart;
+}
+
+/**
+ * @param {number} isoYear
+ * @returns {number}
+ */
+function getISOWeeksInYearUTC(isoYear) {
+    const currentYearStart = getISOWeekStartUTC(isoYear);
+    const nextYearStart = getISOWeekStartUTC(isoYear + 1);
+    return Math.round((nextYearStart.getTime() - currentYearStart.getTime()) / (7 * 24 * 60 * 60 * 1000));
+}
+
+/**
+ * @param {Date} date
+ * @returns {string}
+ */
+function formatUTCDate(date) {
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')}`;
+}
+
+/**
+ * Calculates completed years between two UTC-encoded calendar dates.
+ * @param {Date} currentDateUTC
+ * @param {Date} birthDateUTC
+ * @returns {number}
+ */
+function calculateAgeAtDateUTC(currentDateUTC, birthDateUTC) {
+    let age = currentDateUTC.getUTCFullYear() - birthDateUTC.getUTCFullYear();
+    if (currentDateUTC < addYearsUTC(birthDateUTC, age)) {
+        age--;
+    }
+    return Math.max(0, age);
+}
+
+export {
+    addMonthsUTC,
+    addYearsUTC,
+    calculateAgeAtDateUTC,
+    formatUTCDate,
+    getBrowserTimeZone,
+    getISOWeekStartUTC,
+    getISOWeeksInYearUTC,
+    getISOWeekYearUTC,
+    getLocalDateUTC,
+    startOfISOWeekUTC,
+    startOfMonthUTC
+};

--- a/js/gridRenderer.js
+++ b/js/gridRenderer.js
@@ -6,15 +6,24 @@
  *
  * Exports: `renderAgeGrid`, `renderCalendarGrid`, `renderMonthsGrid`, `renderYearsGrid`.
  *
- * Requires the global `dateFns` object (v4.1.0+); Weeks (Age) uses its date operations,
- * while Calendar, Month, and Year boundaries use native UTC helpers. Expects input
- * `birthDate` to be pre-normalized to UTC midnight by the calling module.
+ * Expects input `birthDate` to be pre-normalized to UTC midnight by the calling module.
  * Defines `LIFE_STAGES` and helper functions internally. Uses `DocumentFragment` for
  * efficient DOM manipulation. Renders content into a specific `gridContentAreaElement`.
  */
 
+import {
+    addMonthsUTC,
+    addYearsUTC,
+    calculateAgeAtDateUTC,
+    formatUTCDate,
+    getISOWeekStartUTC,
+    getISOWeeksInYearUTC,
+    getISOWeekYearUTC,
+    getLocalDateUTC,
+    startOfISOWeekUTC,
+    startOfMonthUTC
+} from './dateUtils.js';
 
-// --- Constants ---
 // Life Stage Definitions (Used for styling blocks)
 // Defines the age boundaries and corresponding CSS class keys for different life stages.
 // Colors are applied via CSS using the '.stage-{key}' classes.
@@ -33,60 +42,6 @@ const LIFE_STAGES = [
     { key: 'latesenior', name: 'Late Senior', maxAge: Infinity }        // (Ages 85+)
 ];
 
-// Helper: normalize a Date to UTC midnight deterministically, independent of local timezone.
-function toUTCStartOfDay(date) {
-    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
-}
-
-function addMonthsUTC(date, months) {
-    const targetMonthIndex = date.getUTCMonth() + months;
-    const targetYear = date.getUTCFullYear() + Math.floor(targetMonthIndex / 12);
-    const targetMonth = ((targetMonthIndex % 12) + 12) % 12;
-    const lastDayOfTargetMonth = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
-    return new Date(Date.UTC(
-        targetYear,
-        targetMonth,
-        Math.min(date.getUTCDate(), lastDayOfTargetMonth)
-    ));
-}
-
-function addYearsUTC(date, years) {
-    return addMonthsUTC(date, Math.trunc(years * 12));
-}
-
-function startOfMonthUTC(date) {
-    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
-}
-
-function startOfISOWeekUTC(date) {
-    const weekStart = toUTCStartOfDay(date);
-    const daysSinceMonday = (weekStart.getUTCDay() + 6) % 7;
-    weekStart.setUTCDate(weekStart.getUTCDate() - daysSinceMonday);
-    return weekStart;
-}
-
-function getISOWeekYearUTC(date) {
-    const thursday = startOfISOWeekUTC(date);
-    thursday.setUTCDate(thursday.getUTCDate() + 3);
-    return thursday.getUTCFullYear();
-}
-
-function getISOWeekStartUTC(isoYear, weekNumber = 1) {
-    const firstWeekStart = startOfISOWeekUTC(new Date(Date.UTC(isoYear, 0, 4)));
-    firstWeekStart.setUTCDate(firstWeekStart.getUTCDate() + ((weekNumber - 1) * 7));
-    return firstWeekStart;
-}
-
-function getISOWeeksInYearUTC(isoYear) {
-    const currentYearStart = getISOWeekStartUTC(isoYear);
-    const nextYearStart = getISOWeekStartUTC(isoYear + 1);
-    return Math.round((nextYearStart - currentYearStart) / (7 * 24 * 60 * 60 * 1000));
-}
-
-function formatUTCDate(date) {
-    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')}`;
-}
-
 // Helper: Get stage key based on age. (Used for styling blocks)
 function getLifeStageKey(age) {
     for (const stage of LIFE_STAGES) {
@@ -97,41 +52,11 @@ function getLifeStageKey(age) {
     return LIFE_STAGES[LIFE_STAGES.length - 1].key; // Default to last stage if somehow needed
 }
 
-// --- Helper: Check if date-fns is loaded ---
-// Ensures the required global library is present before attempting rendering.
-function checkDateFns() {
-    if (typeof dateFns === 'undefined' || typeof dateFns.startOfDay === 'undefined') {
-        console.error("date-fns v4.1.0 library or key functions not loaded!");
-        return false;
-    }
-    // date-fns-tz provides timezone helpers; it's attached to global as dateFnsTz when loaded via CDN
-    if (typeof dateFnsTz === 'undefined' || typeof dateFnsTz.formatInTimeZone === 'undefined') {
-        console.warn('date-fns-tz not found; timezone-aware formatting may be unavailable.');
-    }
-    // If a version string is provided, validate it; otherwise proceed silently.
-    if (typeof dateFns.version === 'string') {
-        if (!dateFns.version.startsWith('4.')) {
-            console.warn(`date-fns object found, but version (${dateFns.version}) might not be v4.1.0+. Ensure correct CDN script is loaded.`);
-        } else {
-            console.log("Using date-fns version:", dateFns.version);
-        }
-    } else {
-        // Tests or non-CDN environments may provide a mocked dateFns without a version.
-        console.log("date-fns object found (version unknown). Proceeding.");
-    }
-    return true;
-}
-
 // --- Helper: Calculate age at a specific date ---
 // Needed for determining life stage in calendar/month views where the block's
 // corresponding date changes relative to the birth date. Uses UTC methods.
 function calculateAgeAtDate(currentDateUTC, birthDateUTC) {
-    let age = currentDateUTC.getUTCFullYear() - birthDateUTC.getUTCFullYear();
-    const monthDiff = currentDateUTC.getUTCMonth() - birthDateUTC.getUTCMonth();
-    if (monthDiff < 0 || (monthDiff === 0 && currentDateUTC.getUTCDate() < birthDateUTC.getUTCDate())) {
-        age--;
-    }
-    return Math.max(0, age);
+    return calculateAgeAtDateUTC(currentDateUTC, birthDateUTC);
 }
 
 /**
@@ -142,27 +67,15 @@ function calculateAgeAtDate(currentDateUTC, birthDateUTC) {
  * @param {HTMLElement} gridContentAreaElement - The DOM element to render the grid blocks into.
  */
 function renderAgeGrid(inputBirthDate, totalLifespanYearsEst, gridContentAreaElement) {
-    if (!checkDateFns()) {
-        if (gridContentAreaElement) gridContentAreaElement.innerHTML = '<p class="error-message">Error: Date library failed to load.</p>';
-        return;
-    }
     if (!gridContentAreaElement) { console.error("Grid content area element not provided."); return; }
 
     console.log("Rendering Age Grid...");
     try {
-        // --- Date Setup (UTC) ---
-        // Ensure all date operations use UTC to avoid timezone/DST issues.
         const birthDateUTC = inputBirthDate; // Already normalized by ui.js
-        // Use date-fns-tz to ensure UTC normalization when available; fall back to core date-fns
-        const nowUTC = toUTCStartOfDay(new Date());
-        const currentActualWeekStartDateUTC = dateFns.startOfISOWeek(nowUTC);
-        const estimatedEndDateRough = dateFns.addYears(birthDateUTC, totalLifespanYearsEst);
-        const estimatedEndDateUTC = toUTCStartOfDay(estimatedEndDateRough);
+        const currentActualWeekStartDateUTC = startOfISOWeekUTC(getLocalDateUTC());
+        const estimatedEndDateUTC = addYearsUTC(birthDateUTC, totalLifespanYearsEst);
 
-
-        // --- Grid Rendering ---
-        gridContentAreaElement.innerHTML = ''; // Clear previous content from the specific area
-        // Use a DocumentFragment to batch DOM updates for better performance
+        gridContentAreaElement.innerHTML = '';
         const fragment = document.createDocumentFragment();
         let totalRenderedWeeks = 0;
         const totalYearsToRender = Math.ceil(totalLifespanYearsEst);
@@ -173,65 +86,36 @@ function renderAgeGrid(inputBirthDate, totalLifespanYearsEst, gridContentAreaEle
             ageRow.setAttribute('data-age', age);
             ageRow.setAttribute('aria-label', `Age ${age}`);
 
-            const ageStartDateUTC = toUTCStartOfDay(dateFns.addYears(birthDateUTC, age));
-            const ageEndDateExclusiveUTC = toUTCStartOfDay(dateFns.addYears(birthDateUTC, age + 1));
-
+            const ageStartDateUTC = addYearsUTC(birthDateUTC, age);
+            const ageEndDateExclusiveUTC = addYearsUTC(birthDateUTC, age + 1);
             const stageKey = getLifeStageKey(age);
 
-            // === Week Generation Logic for Age View ===
-            // This section ensures accurate week representation for each year of age,
-            // handling the 52/53 week variation and edge cases near birthdays.
-            // 1. Get all ISO weeks overlapping the interval [ageStartDate, ageEndDateExclusive).
-            // 2. Filter to keep only weeks starting strictly BEFORE the next birthday (ageEndDateExclusive).
-            // 3. If the filtered list has 54 weeks (rare edge case), remove the last one
-            //    to enforce a visual maximum of 53 weeks per row.
-            let weeksInAgeYearRaw = []; // Weeks overlapping the interval
-            let weeksInAgeYearFiltered = []; // Weeks starting strictly before next birthday
-            let weeksInAgeYearFinal = []; // Max 53 weeks for display
-
-            if (dateFns.isBefore(ageStartDateUTC, ageEndDateExclusiveUTC)) {
-                // Step 1: Get overlapping weeks (Monday starts)
-                weeksInAgeYearRaw = dateFns.eachWeekOfInterval({
-                    start: ageStartDateUTC,
-                    end: ageEndDateExclusiveUTC
-                }, { weekStartsOn: 1 }); // 1 = Monday for ISO
-
-                // Step 2: Filter weeks starting before the next birthday
-                weeksInAgeYearFiltered = weeksInAgeYearRaw.filter(weekStart =>
-                    dateFns.isBefore(weekStart, ageEndDateExclusiveUTC)
-                );
-
-                // Step 3: Enforce max 53 weeks visually
-                weeksInAgeYearFinal = [...weeksInAgeYearFiltered]; // Copy the array
-                if (weeksInAgeYearFinal.length === 54) {
-                    console.warn(`Age ${age}: Filtered list had 54 weeks. Removing the last week (${dateFns.format(weeksInAgeYearFinal[weeksInAgeYearFinal.length - 1], 'yyyy-MM-dd')}) to enforce max 53.`);
-                    weeksInAgeYearFinal.pop(); // Remove the last element
-                }
-            } else {
-                 console.warn(`Age ${age}: Start date not before end date. Skipping row.`);
+            const weeksInAgeYear = [];
+            let weekStartDateUTC = startOfISOWeekUTC(ageStartDateUTC);
+            while (weekStartDateUTC < ageEndDateExclusiveUTC) {
+                weeksInAgeYear.push(weekStartDateUTC);
+                weekStartDateUTC = new Date(weekStartDateUTC.getTime());
+                weekStartDateUTC.setUTCDate(weekStartDateUTC.getUTCDate() + 7);
+            }
+            if (weeksInAgeYear.length > 53) {
+                console.warn(`Age ${age}: Generated ${weeksInAgeYear.length} weeks. Removing the last week (${formatUTCDate(weeksInAgeYear[weeksInAgeYear.length - 1])}) to enforce max 53.`);
+                weeksInAgeYear.length = 53;
             }
 
             let weekInAgeYearIndex = 0;
-            for (const currentRenderWeekStartDateUTC of weeksInAgeYearFinal) {
-                // Ensure the week start is not after the estimated end of life
-                 if (dateFns.isAfter(currentRenderWeekStartDateUTC, estimatedEndDateUTC)) {
-                    continue; // Don't render blocks past the estimated end date
-                 }
+            for (const currentRenderWeekStartDateUTC of weeksInAgeYear) {
+                if (currentRenderWeekStartDateUTC > estimatedEndDateUTC) continue;
 
                 const weekBlock = document.createElement('div');
                 weekBlock.classList.add('week-block');
                 weekBlock.classList.add(`stage-${stageKey}`);
                 let stateClass = '';
-                    // Use date-fns-tz.formatInTimeZone for timezone-aware formatting if available
-                    let formattedStart = (typeof dateFnsTz !== 'undefined' && dateFnsTz.formatInTimeZone)
-                        ? dateFnsTz.formatInTimeZone(currentRenderWeekStartDateUTC, 'UTC', 'yyyy-MM-dd')
-                        : dateFns.format(currentRenderWeekStartDateUTC, 'yyyy-MM-dd');
-                    let title = `Age ${age}, Week ${weekInAgeYearIndex + 1} (Starts UTC: ${formattedStart})`;
+                const formattedStart = formatUTCDate(currentRenderWeekStartDateUTC);
+                let title = `Age ${age}, Week ${weekInAgeYearIndex + 1} (Starts UTC: ${formattedStart})`;
 
-                // Determine state (past/present/future) by comparing week start dates
                 if (currentRenderWeekStartDateUTC.getTime() === currentActualWeekStartDateUTC.getTime()) {
                     stateClass = 'present'; title += ' (Current week)';
-                } else if (dateFns.isBefore(currentRenderWeekStartDateUTC, currentActualWeekStartDateUTC)) {
+                } else if (currentRenderWeekStartDateUTC < currentActualWeekStartDateUTC) {
                     stateClass = 'past';
                 } else {
                     stateClass = 'future';
@@ -247,7 +131,6 @@ function renderAgeGrid(inputBirthDate, totalLifespanYearsEst, gridContentAreaEle
             if (ageRow.hasChildNodes()) fragment.appendChild(ageRow);
         }
 
-        // Append the completed fragment to the specific content area
         gridContentAreaElement.appendChild(fragment);
         console.log(`Total weeks rendered in age grid: ${totalRenderedWeeks}`);
 
@@ -267,24 +150,20 @@ function renderAgeGrid(inputBirthDate, totalLifespanYearsEst, gridContentAreaEle
  * @param {HTMLElement} gridContentAreaElement - The DOM element to render the grid blocks into.
  */
 function renderCalendarGrid(inputBirthDate, totalLifespanYearsEst, gridContentAreaElement) {
-    if (!checkDateFns()) {
-        if (gridContentAreaElement) gridContentAreaElement.innerHTML = '<p class="error-message">Error: Date library failed to load.</p>';
-        return;
-    }
     if (!gridContentAreaElement) { console.error("Grid content area element not provided."); return; }
 
     console.log("Rendering Calendar Grid...");
     try {
         // --- Date Setup (UTC) ---
         const birthDateUTC = inputBirthDate; // Already normalized by ui.js
-        const nowUTC = toUTCStartOfDay(new Date());
+        const todayUTC = getLocalDateUTC();
         const estimatedEndDateUTC = addYearsUTC(birthDateUTC, totalLifespanYearsEst);
         const startISOYear = getISOWeekYearUTC(birthDateUTC);
         const endISOYear = getISOWeekYearUTC(estimatedEndDateUTC);
         // Determine the start of the ISO week containing the birth date
         const firstWeekStartDateUTC = startOfISOWeekUTC(birthDateUTC);
         // Determine the start of the current ISO week
-        const currentActualWeekStartDateUTC = startOfISOWeekUTC(nowUTC);
+        const currentActualWeekStartDateUTC = startOfISOWeekUTC(todayUTC);
 
         // --- Grid Rendering ---
         gridContentAreaElement.innerHTML = ''; // Clear previous content from the specific area
@@ -319,12 +198,12 @@ function renderCalendarGrid(inputBirthDate, totalLifespanYearsEst, gridContentAr
                 let title = `Year ${isoYear}, Week ${weekNum} (Starts UTC: ${formattedStart})`;
 
                 // Check Out of Bounds: Is this week before the first week containing birth OR after estimated end?
-                if (dateFns.isBefore(currentRenderWeekStartDateUTC, firstWeekStartDateUTC) || dateFns.isAfter(currentRenderWeekStartDateUTC, estimatedEndDateUTC)) {
+                if (currentRenderWeekStartDateUTC < firstWeekStartDateUTC || currentRenderWeekStartDateUTC > estimatedEndDateUTC) {
                     stateClass = 'out-of-bounds'; title += ' (Outside lifespan)';
                 } else { // Within lifespan, check past/present/future
                     if (currentRenderWeekStartDateUTC.getTime() === currentActualWeekStartDateUTC.getTime()) {
                         stateClass = 'present'; title += ' (Current week)';
-                    } else if (dateFns.isBefore(currentRenderWeekStartDateUTC, currentActualWeekStartDateUTC)) {
+                    } else if (currentRenderWeekStartDateUTC < currentActualWeekStartDateUTC) {
                         stateClass = 'past';
                     } else {
                         stateClass = 'future';
@@ -360,18 +239,13 @@ function renderCalendarGrid(inputBirthDate, totalLifespanYearsEst, gridContentAr
  * @param {HTMLElement} gridContentAreaElement - The DOM element to render the grid blocks into.
  */
 function renderMonthsGrid(inputBirthDate, totalLifespanYearsEst, gridContentAreaElement) {
-    if (!checkDateFns()) {
-        if (gridContentAreaElement) gridContentAreaElement.innerHTML = '<p class="error-message">Error: Date library failed to load.</p>';
-        return;
-    }
     if (!gridContentAreaElement) { console.error("Grid content area element not provided."); return; }
 
     console.log("Rendering Months Grid...");
     try {
         // --- Date Setup (UTC) ---
         const birthDateUTC = inputBirthDate; // Already normalized by ui.js
-        const nowUTC = toUTCStartOfDay(new Date());
-        const currentMonthStartDateUTC = startOfMonthUTC(nowUTC);
+        const currentMonthStartDateUTC = startOfMonthUTC(getLocalDateUTC());
 
         // Calculate total months to potentially render based on estimated lifespan
         const totalEstimatedMonths = Math.ceil(totalLifespanYearsEst * 12);
@@ -453,17 +327,13 @@ function renderMonthsGrid(inputBirthDate, totalLifespanYearsEst, gridContentArea
  * @param {HTMLElement} gridContentAreaElement - The DOM element to render the grid blocks into.
  */
 function renderYearsGrid(inputBirthDate, totalLifespanYearsEst, gridContentAreaElement) {
-    if (!checkDateFns()) {
-        if (gridContentAreaElement) gridContentAreaElement.innerHTML = '<p class="error-message">Error: Date library failed to load.</p>';
-        return;
-    }
     if (!gridContentAreaElement) { console.error("Grid content area element not provided."); return; }
 
     console.log("Rendering Years Grid (Decades)...");
     try {
         // --- Date Setup (UTC) ---
         const birthDateUTC = inputBirthDate; // Already normalized by ui.js
-        const nowUTC = toUTCStartOfDay(new Date());
+        const todayUTC = getLocalDateUTC();
 
         // Calculate total years to potentially render (ceiling of estimated lifespan)
         const totalEstimatedYears = Math.ceil(totalLifespanYearsEst);
@@ -503,9 +373,9 @@ function renderYearsGrid(inputBirthDate, totalLifespanYearsEst, gridContentAreaE
             const formattedStart = formatUTCDate(yearStartDateUTC);
             let title = `Age ${ageForThisYear} (Starts UTC: ${formattedStart})`;
 
-            if (nextYearStartDateUTC <= nowUTC) {
+            if (nextYearStartDateUTC <= todayUTC) {
                 stateClass = 'past';
-            } else if (yearStartDateUTC <= nowUTC) {
+            } else if (yearStartDateUTC <= todayUTC) {
                 stateClass = 'present'; title += ' (Current year)';
             } else {
                 stateClass = 'future';

--- a/js/ui.js
+++ b/js/ui.js
@@ -12,6 +12,7 @@
 
 // Import calculation functions
 import { calculateCurrentAge, getRemainingExpectancy } from './calculator.js';
+import { getBrowserTimeZone, getLocalDateUTC } from './dateUtils.js';
 // Import grid rendering functions
 import { renderAgeGrid, renderCalendarGrid, renderMonthsGrid, renderYearsGrid } from './gridRenderer.js';
 
@@ -43,7 +44,8 @@ let currentView = DEFAULT_VIEW; // Matches the default button in index.html
 // Stores results of the last calculation to allow re-rendering on view change without recalculating
 let lastCalcData = {
     birthDate: null, // Stores the UTC-normalized birthDate object
-    totalLifespanYearsEst: null
+    totalLifespanYearsEst: null,
+    timeZone: null
 };
 
 /**
@@ -53,13 +55,7 @@ let lastCalcData = {
 function areInputsValid() {
     const birthDateUTC = parseBirthdateUTC(birthdateInput?.value);
     const sexSelected = sexInput && sexInput.value !== ''; // "Select..." option has value=""
-    return Boolean(birthDateUTC && birthDateUTC < getTodayUTC() && sexSelected);
-}
-
-function getTodayUTC() {
-    const now = new Date();
-    // Represent the user's local calendar date at UTC midnight for date-only comparisons.
-    return new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()));
+    return Boolean(birthDateUTC && birthDateUTC < getLocalDateUTC() && sexSelected);
 }
 
 function formatDateInputValue(date) {
@@ -264,6 +260,7 @@ async function handleCalculation(event) {
     // Clear previous calculation data before starting new calculation
     lastCalcData.birthDate = null;
     lastCalcData.totalLifespanYearsEst = null;
+    lastCalcData.timeZone = null;
 
     // --- Input Validation ---
     if (!birthdateStr || !sex) {
@@ -276,7 +273,7 @@ async function handleCalculation(event) {
     const birthDateUTC = parseBirthdateUTC(birthdateStr);
 
     // Check validity and ensure date is in the past.
-    if (!birthDateUTC || birthDateUTC >= getTodayUTC()) {
+    if (!birthDateUTC || birthDateUTC >= getLocalDateUTC()) {
         displayError('Please enter a valid birth date in the past (YYYY-MM-DD).');
         renderCurrentView(); // Clear grid content area if validation fails
         finalizeCalculation();
@@ -297,6 +294,7 @@ async function handleCalculation(event) {
         // --- Store Calculation Results ---
         lastCalcData.birthDate = birthDateUTC;
         lastCalcData.totalLifespanYearsEst = totalEstimatedLifespan;
+        lastCalcData.timeZone = getBrowserTimeZone();
 
         // --- Display Results ---
         displayResults(currentAge, remainingYears, totalEstimatedLifespan, birthDateUTC, sex); // Pass inputs for display
@@ -422,6 +420,7 @@ function handleStartOver() {
     // Reset stored calculation data
     lastCalcData.birthDate = null;
     lastCalcData.totalLifespanYearsEst = null;
+    lastCalcData.timeZone = null;
 
     currentView = DEFAULT_VIEW;
     viewSwitcherButtons.forEach(button => {
@@ -523,7 +522,7 @@ function setupEventListeners() {
 
     // Add event listeners to form inputs to update button state
     if (birthdateInput) {
-        const yesterdayUTC = getTodayUTC();
+        const yesterdayUTC = getLocalDateUTC();
         yesterdayUTC.setUTCDate(yesterdayUTC.getUTCDate() - 1);
         birthdateInput.max = formatDateInputValue(yesterdayUTC);
         birthdateInput.addEventListener('input', updateButtonState);

--- a/tests/unit/calculator.test.js
+++ b/tests/unit/calculator.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
+let originalTimezone;
+
 /**
  * Tests for js/calculator.js
  *
@@ -10,13 +12,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
  */
 
 beforeEach(() => {
-  // Ensure a clean module registry before each test and freeze time by default.
+  originalTimezone = process.env.TZ;
+  process.env.TZ = 'UTC';
   vi.resetModules();
   vi.useFakeTimers();
   vi.setSystemTime(new Date('2025-11-10T00:00:00Z'));
 });
 
 afterEach(() => {
+  if (originalTimezone === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTimezone;
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
@@ -35,20 +40,18 @@ describe('calculator', () => {
       expect(calculateCurrentAge(birth)).toBe(24);
     });
 
-    it('handles leap day birthdays correctly (birthday not yet reached)', async () => {
+    it('uses February 28 as the anniversary for leap-day birthdays in non-leap years', async () => {
       const { calculateCurrentAge } = await import('../../js/calculator.js');
       const birth = new Date('2004-02-29T00:00:00Z');
-      // 2025-02-28 should be considered before birthday => age 20
       vi.setSystemTime(new Date('2025-02-28T00:00:00Z'));
-      expect(calculateCurrentAge(birth)).toBe(20);
+      expect(calculateCurrentAge(birth)).toBe(21);
     });
 
-    it('handles leap day birthdays correctly (birthday passed on Mar 1)', async () => {
+    it('does not increment a leap-day age before the February 28 anniversary', async () => {
       const { calculateCurrentAge } = await import('../../js/calculator.js');
       const birth = new Date('2004-02-29T00:00:00Z');
-      // 2025-03-01 should be after the birthday => age 21
-      vi.setSystemTime(new Date('2025-03-01T00:00:00Z'));
-      expect(calculateCurrentAge(birth)).toBe(21);
+      vi.setSystemTime(new Date('2025-02-27T23:59:59Z'));
+      expect(calculateCurrentAge(birth)).toBe(20);
     });
 
     it('returns 0 for future birth dates', async () => {
@@ -57,20 +60,28 @@ describe('calculator', () => {
       expect(calculateCurrentAge(birth)).toBe(0);
     });
 
-    it('increments age exactly at UTC birthday moment', async () => {
+    it.each([
+      ['UTC', '2025-11-09T23:59:59Z', '2025-11-10T00:00:00Z'],
+      ['America/Los_Angeles', '2025-11-10T07:59:59Z', '2025-11-10T08:00:00Z'],
+      ['Asia/Tokyo', '2025-11-09T14:59:59Z', '2025-11-09T15:00:00Z'],
+      ['Pacific/Auckland', '2025-11-09T10:59:59Z', '2025-11-09T11:00:00Z'],
+    ])('increments age at local midnight in %s', async (timezone, beforeMidnight, atMidnight) => {
+      process.env.TZ = timezone;
       const { calculateCurrentAge } = await import('../../js/calculator.js');
-      // Birthday: 2000-11-10 UTC. If system time equals 2025-11-10T00:00:00Z, age should be 25.
-      vi.setSystemTime(new Date('2025-11-10T00:00:00Z'));
       const birth = new Date('2000-11-10T00:00:00Z');
+
+      vi.setSystemTime(new Date(beforeMidnight));
+      expect(calculateCurrentAge(birth)).toBe(24);
+      vi.setSystemTime(new Date(atMidnight));
       expect(calculateCurrentAge(birth)).toBe(25);
     });
 
-    it('does not increment age one second before UTC birthday', async () => {
+    it('accepts an explicit UTC-encoded current calendar date', async () => {
       const { calculateCurrentAge } = await import('../../js/calculator.js');
-      // One second before UTC midnight of birthday
-      vi.setSystemTime(new Date('2025-11-09T23:59:59Z'));
       const birth = new Date('2000-11-10T00:00:00Z');
-      expect(calculateCurrentAge(birth)).toBe(24);
+
+      expect(calculateCurrentAge(birth, new Date('2025-11-09T00:00:00Z'))).toBe(24);
+      expect(calculateCurrentAge(birth, new Date('2025-11-10T00:00:00Z'))).toBe(25);
     });
 
     it('throws error for invalid birth date', async () => {
@@ -78,6 +89,13 @@ describe('calculator', () => {
       expect(() => calculateCurrentAge("invalid")).toThrowError('Invalid birthDate provided to calculateCurrentAge');
       expect(() => calculateCurrentAge(null)).toThrowError('Invalid birthDate provided to calculateCurrentAge');
       expect(() => calculateCurrentAge(undefined)).toThrowError('Invalid birthDate provided to calculateCurrentAge');
+    });
+
+    it('throws error for an invalid current date', async () => {
+      const { calculateCurrentAge } = await import('../../js/calculator.js');
+      const birth = new Date('2000-11-10T00:00:00Z');
+      expect(() => calculateCurrentAge(birth, new Date('invalid')))
+        .toThrowError('Invalid currentDateUTC provided to calculateCurrentAge');
     });
   });
 

--- a/tests/unit/dateUtils.test.js
+++ b/tests/unit/dateUtils.test.js
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  addMonthsUTC,
+  addYearsUTC,
+  getBrowserTimeZone,
+  getISOWeekStartUTC,
+  getISOWeeksInYearUTC,
+  getLocalDateUTC,
+  startOfISOWeekUTC,
+} from '../../js/dateUtils.js';
+
+const TEST_TIMEZONES = [
+  ['UTC', '2025-01-01T00:30:00Z', '2025-01-01'],
+  ['America/Los_Angeles', '2025-01-01T00:30:00Z', '2024-12-31'],
+  ['Europe/London', '2025-01-01T00:30:00Z', '2025-01-01'],
+  ['Asia/Tokyo', '2024-12-31T16:00:00Z', '2025-01-01'],
+  ['Pacific/Auckland', '2024-12-31T11:30:00Z', '2025-01-01'],
+];
+
+describe('dateUtils', () => {
+  let originalTimezone;
+
+  beforeEach(() => {
+    originalTimezone = process.env.TZ;
+  });
+
+  afterEach(() => {
+    if (originalTimezone === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTimezone;
+    vi.restoreAllMocks();
+  });
+
+  it.each(TEST_TIMEZONES)(
+    'encodes the local calendar date in %s',
+    (timezone, instant, expectedDate) => {
+      process.env.TZ = timezone;
+      expect(getLocalDateUTC(new Date(instant)).toISOString().slice(0, 10)).toBe(expectedDate);
+    },
+  );
+
+  it('keeps the local date stable across a daylight-saving transition', () => {
+    process.env.TZ = 'America/Los_Angeles';
+    expect(getLocalDateUTC(new Date('2025-03-09T09:59:59Z')).toISOString().slice(0, 10))
+      .toBe('2025-03-09');
+    expect(getLocalDateUTC(new Date('2025-03-09T10:00:00Z')).toISOString().slice(0, 10))
+      .toBe('2025-03-09');
+  });
+
+  it('reports the resolved IANA timezone and falls back to UTC', () => {
+    process.env.TZ = 'Asia/Tokyo';
+    expect(getBrowserTimeZone()).toBe('Asia/Tokyo');
+
+    vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(() => {
+      throw new Error('unsupported');
+    });
+    expect(getBrowserTimeZone()).toBe('UTC');
+  });
+
+  it('clamps month-end and leap-day calendar arithmetic', () => {
+    expect(addMonthsUTC(new Date('2025-01-31T00:00:00Z'), 1).toISOString().slice(0, 10))
+      .toBe('2025-02-28');
+    expect(addYearsUTC(new Date('2024-02-29T00:00:00Z'), 1).toISOString().slice(0, 10))
+      .toBe('2025-02-28');
+  });
+
+  it('adds months across years in both directions', () => {
+    expect(addMonthsUTC(new Date('2025-01-31T00:00:00Z'), -1).toISOString().slice(0, 10))
+      .toBe('2024-12-31');
+    expect(addMonthsUTC(new Date('2025-10-31T00:00:00Z'), 15).toISOString().slice(0, 10))
+      .toBe('2027-01-31');
+  });
+
+  it('adds fractional and negative years with month precision', () => {
+    expect(addYearsUTC(new Date('2024-02-29T00:00:00Z'), -1).toISOString().slice(0, 10))
+      .toBe('2023-02-28');
+    expect(addYearsUTC(new Date('2024-02-29T00:00:00Z'), 1.5).toISOString().slice(0, 10))
+      .toBe('2025-08-29');
+  });
+
+  it('calculates ISO week boundaries including 53-week years', () => {
+    expect(startOfISOWeekUTC(new Date('2025-01-05T00:00:00Z')).toISOString().slice(0, 10))
+      .toBe('2024-12-30');
+    expect(getISOWeekStartUTC(2026).toISOString().slice(0, 10)).toBe('2025-12-29');
+    expect(getISOWeeksInYearUTC(2025)).toBe(52);
+    expect(getISOWeeksInYearUTC(2026)).toBe(53);
+  });
+});

--- a/tests/unit/gridRenderer.calendar.test.js
+++ b/tests/unit/gridRenderer.calendar.test.js
@@ -1,95 +1,44 @@
-/**
- * tests/unit/gridRenderer.calendar.test.js
- *
- * Tests for renderCalendarGrid (ISO weeks, out-of-bounds)
- */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupJSDOM, teardownJSDOM } from '../setup/jsdom-helper.js';
 
 describe('gridRenderer calendar view', () => {
+  let dom;
+  let originalTimezone;
+
   beforeEach(async () => {
-    // Reset module cache so we can inject a fresh global `dateFns` mock before importing the renderer.
     vi.resetModules();
-
-    // Create a JSDOM document/window so DOM APIs are available in Node test environment.
-    const { JSDOM } = await import('jsdom');
-    const dom = new JSDOM('<!doctype html><html><body></body></html>');
-    // Expose minimal globals used by the renderer and tests
-    global.window = dom.window;
-    global.document = dom.window.document;
-    global.HTMLElement = dom.window.HTMLElement;
-    global.Node = dom.window.Node;
-
-    // Minimal date-fns mock implementing only functions used by renderCalendarGrid for this test.
-    global.dateFns = {
-      startOfDay: (d) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())),
-      startOfISOWeek: (d) => {
-        const dt = new Date(d);
-        const day = dt.getUTCDay(); // 0 (Sun) .. 6 (Sat)
-        // ISO week starts on Monday (1). Compute diff to Monday.
-        const diff = (day === 0 ? -6 : 1) - day;
-        return new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth(), dt.getUTCDate() + diff));
-      },
-      addYears: (d, n) => new Date(Date.UTC(d.getUTCFullYear() + n, d.getUTCMonth(), d.getUTCDate())),
-      getISOWeekYear: (d) => {
-        // Simple implementation for testing
-        const date = new Date(d);
-        const day = date.getUTCDay();
-        const thursday = new Date(date);
-        thursday.setUTCDate(date.getUTCDate() + (4 - day));
-        return thursday.getUTCFullYear();
-      },
-      getISOWeeksInYear: (_d) => {
-        // Simple implementation for testing
-        return 52; // Default to 52 weeks in year
-      },
-      setISOWeekYear: (date, isoYear) => new Date(Date.UTC(isoYear, 0, 4)),
-      setISOWeek: (date, weekNum) => {
-        const firstWeekMonday = new Date(Date.UTC(date.getUTCFullYear(), 0, 4));
-        return new Date(firstWeekMonday.getTime() + (weekNum - 1) * 7 * 24 * 60 * 60 * 1000);
-      },
-      format: (d, _fmt, _opts) => {
-        const y = d.getUTCFullYear();
-        const m = String(d.getUTCMonth() + 1).padStart(2, '0');
-        const day = String(d.getUTCDate()).padStart(2, '0');
-        return `${y}-${m}-${day}`;
-      },
-      isBefore: (a, b) => a.getTime() < b.getTime(),
-      isAfter: (a, b) => a.getTime() > b.getTime(),
-    };
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-06T12:00:00Z'));
+    originalTimezone = process.env.TZ;
+    process.env.TZ = 'UTC';
+    dom = await setupJSDOM();
   });
 
-  it('renders calendar rows and marks out-of-bounds weeks and no error when dateFns present', async () => {
-    const { renderCalendarGrid } = await import('../../js/gridRenderer.js');
+  afterEach(() => {
+    if (originalTimezone === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTimezone;
+    teardownJSDOM(dom);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 
-    const birthDateUTC = new Date(Date.UTC(2000, 0, 1)); // 2000-01-01 UTC
-    const totalYears = 2; // render roughly 2 years of weeks
+  it('renders calendar rows and marks lifespan boundaries', async () => {
+    const { renderCalendarGrid } = await import('../../js/gridRenderer.js');
     const container = document.createElement('div');
 
-    // Call renderer
-    renderCalendarGrid(birthDateUTC, totalYears, container);
+    renderCalendarGrid(new Date('2000-01-01T00:00:00Z'), 2, container);
 
-    // Should have year-row elements appended
-    const rows = container.querySelectorAll('.year-row');
-    expect(rows.length).toBeGreaterThan(0);
-
-    // Should not show error message
+    expect(container.querySelectorAll('.year-row').length).toBeGreaterThan(0);
     expect(container.querySelector('.error-message')).toBeNull();
-
-    // There should be at least one out-of-bounds block (weeks before birth or after end)
-    const oob = container.querySelectorAll('.out-of-bounds');
-    expect(oob.length).toBeGreaterThan(0);
-
-    // Ensure at least one week-block exists and has title with 'Year'
-    const someWeek = container.querySelector('.week-block');
-    expect(someWeek).not.toBeNull();
-    expect(someWeek.title).toContain('Year');
+    expect(container.querySelectorAll('.out-of-bounds').length).toBeGreaterThan(0);
+    expect(container.querySelector('.week-block')?.title).toContain('Year');
   });
 
   it('calculates known 52 and 53 week ISO years from UTC boundaries', async () => {
     const { renderCalendarGrid } = await import('../../js/gridRenderer.js');
     const container = document.createElement('div');
 
-    renderCalendarGrid(new Date(Date.UTC(2014, 0, 1)), 14, container);
+    renderCalendarGrid(new Date('2014-01-01T00:00:00Z'), 14, container);
 
     const expectedYears = [
       { year: 2015, count: 53, firstStart: '2014-12-29' },
@@ -100,130 +49,51 @@ describe('gridRenderer calendar view', () => {
       { year: 2026, count: 53, firstStart: '2025-12-29' },
     ];
 
-    expectedYears.forEach(({ year, count, firstStart }) => {
-      const row = container.querySelector(`[data-year="${year}"]`);
-      const weekBlocks = [...row.querySelectorAll('.week-block')];
-      expect(weekBlocks).toHaveLength(count);
-      expect(weekBlocks[0].title).toContain(`Starts UTC: ${firstStart}`);
-      expect(new Set(weekBlocks.map((block) => block.title)).size).toBe(count);
-    });
+    for (const { year, count, firstStart } of expectedYears) {
+      const blocks = [...container.querySelectorAll(`[data-year="${year}"] .week-block`)];
+      expect(blocks).toHaveLength(count);
+      expect(blocks[0].title).toContain(`Starts UTC: ${firstStart}`);
+      expect(new Set(blocks.map((block) => block.title)).size).toBe(count);
+    }
   });
 
-  it('preserves fractional lifespan years when determining the final ISO year', async () => {
+  it('preserves fractional lifespan years through the final ISO year', async () => {
     const { renderCalendarGrid } = await import('../../js/gridRenderer.js');
     const container = document.createElement('div');
 
-    renderCalendarGrid(new Date(Date.UTC(2020, 0, 1)), 1.5, container);
+    renderCalendarGrid(new Date('2020-01-01T00:00:00Z'), 1.5, container);
 
     expect(container.querySelector('[data-year="2021"]')).not.toBeNull();
   });
 
-  it('does not throw and renders rows spanning ISO year boundaries (Dec 31 births)', async () => {
-    vi.resetModules();
-    const { JSDOM } = await import('jsdom');
-    const dom = new JSDOM('<!doctype html><html><body></body></html>');
-    global.window = dom.window;
-    global.document = dom.window.document;
-    global.HTMLElement = dom.window.HTMLElement;
-    global.Node = dom.window.Node;
-
-    // Basic date-fns mock sufficient for boundary behavior
-    global.dateFns = {
-      startOfDay: (d) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())),
-      startOfISOWeek: (d) => {
-        const dt = new Date(d);
-        const day = dt.getUTCDay();
-        const diff = (day === 0 ? -6 : 1) - day;
-        return new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth(), dt.getUTCDate() + diff));
-      },
-      addYears: (d, n) => new Date(Date.UTC(d.getUTCFullYear() + n, d.getUTCMonth(), d.getUTCDate())),
-      getISOWeekYear: (d) => {
-        const date = new Date(d);
-        const day = date.getUTCDay();
-        const thursday = new Date(date);
-        thursday.setUTCDate(date.getUTCDate() + (4 - day));
-        return thursday.getUTCFullYear();
-      },
-      getISOWeeksInYear: () => 52,
-      setISOWeekYear: (date, isoYear) => new Date(Date.UTC(isoYear, 0, 4)),
-      setISOWeek: (date, weekNum) => {
-        const firstWeekMonday = new Date(Date.UTC(date.getUTCFullYear(), 0, 4));
-        return new Date(firstWeekMonday.getTime() + (weekNum - 1) * 7 * 24 * 60 * 60 * 1000);
-      },
-      format: (d) => {
-        const y = d.getUTCFullYear();
-        const m = String(d.getUTCMonth() + 1).padStart(2, '0');
-        const day = String(d.getUTCDate()).padStart(2, '0');
-        return `${y}-${m}-${day}`;
-      },
-      isBefore: (a, b) => a.getTime() < b.getTime(),
-      isAfter: (a, b) => a.getTime() > b.getTime(),
-    };
-
-    const { renderCalendarGrid } = await import('../../js/gridRenderer.js');
-
-    // Birthdate Dec 31 which can fall into ISO week of the following year
-    const birthDateUTC = new Date(Date.UTC(2020, 11, 31));
-    const totalYears = 2;
-    const container = document.createElement('div');
-
-    // This should not throw and should render year-row elements for the span
-    renderCalendarGrid(birthDateUTC, totalYears, container);
-
-    const rows = container.querySelectorAll('.year-row');
-    expect(rows.length).toBeGreaterThanOrEqual(1);
-
-    // Ensure week blocks exist and have titles (indicating successful render)
-    const weekBlocks = container.querySelectorAll('.week-block');
-    expect(weekBlocks.length).toBeGreaterThan(0);
-    expect(weekBlocks[0].title).toContain('Year');
-  });
-
-  it('marks present and future weeks when blocks are within lifespan bounds', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-01-06T00:00:00Z'));
-
-    vi.resetModules();
-    const { JSDOM } = await import('jsdom');
-    const dom = new JSDOM('<!doctype html><html><body></body></html>');
-    global.window = dom.window;
-    global.document = dom.window.document;
-    global.HTMLElement = dom.window.HTMLElement;
-    global.Node = dom.window.Node;
-
-    global.dateFns = {
-      startOfDay: (d) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())),
-      startOfISOWeek: (d) => {
-        const dt = new Date(d);
-        const day = dt.getUTCDay();
-        const diff = (day === 0 ? -6 : 1) - day;
-        return new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth(), dt.getUTCDate() + diff));
-      },
-      addYears: (d, n) => new Date(Date.UTC(d.getUTCFullYear() + n, d.getUTCMonth(), d.getUTCDate())),
-      getISOWeekYear: (d) => new Date(d).getUTCFullYear(),
-      getISOWeeksInYear: () => 3,
-      setISOWeekYear: (_date, isoYear) => new Date(Date.UTC(isoYear, 0, 4)),
-      setISOWeek: (date, weekNum) => {
-        const firstWeekMonday = new Date(Date.UTC(date.getUTCFullYear(), 0, 6));
-        return new Date(firstWeekMonday.getTime() + (weekNum - 1) * 7 * 24 * 60 * 60 * 1000);
-      },
-      format: (d) => {
-        const y = d.getUTCFullYear();
-        const m = String(d.getUTCMonth() + 1).padStart(2, '0');
-        const day = String(d.getUTCDate()).padStart(2, '0');
-        return `${y}-${m}-${day}`;
-      },
-      isBefore: (a, b) => a.getTime() < b.getTime(),
-      isAfter: (a, b) => a.getTime() > b.getTime(),
-    };
-
+  it('renders rows across a December 31 ISO year boundary', async () => {
     const { renderCalendarGrid } = await import('../../js/gridRenderer.js');
     const container = document.createElement('div');
-    renderCalendarGrid(new Date(Date.UTC(2025, 0, 6)), 1, container);
 
-    expect(container.querySelectorAll('.present').length).toBeGreaterThanOrEqual(1);
-    expect(container.querySelectorAll('.future').length).toBeGreaterThanOrEqual(1);
-    vi.useRealTimers();
+    renderCalendarGrid(new Date('2020-12-31T00:00:00Z'), 2, container);
+
+    expect(container.querySelectorAll('.year-row').length).toBeGreaterThanOrEqual(1);
+    expect(container.querySelector('.week-block')?.title).toContain('Year');
   });
 
+  it('marks the current local calendar week across a UTC date rollover', async () => {
+    const { renderCalendarGrid } = await import('../../js/gridRenderer.js');
+    vi.setSystemTime(new Date('2025-01-06T01:00:00Z'));
+
+    const expectations = [
+      ['America/Los_Angeles', 'Starts UTC: 2024-12-30'],
+      ['UTC', 'Starts UTC: 2025-01-06'],
+      ['Asia/Tokyo', 'Starts UTC: 2025-01-06'],
+    ];
+
+    for (const [timezone, expectedStart] of expectations) {
+      process.env.TZ = timezone;
+      const container = document.createElement('div');
+      renderCalendarGrid(new Date('2024-01-01T00:00:00Z'), 2, container);
+
+      expect(container.querySelectorAll('.present')).toHaveLength(1);
+      expect(container.querySelector('.present')?.title).toContain(expectedStart);
+      expect(container.querySelectorAll('.future').length).toBeGreaterThan(0);
+    }
+  });
 });

--- a/tests/unit/gridRenderer.edge.test.js
+++ b/tests/unit/gridRenderer.edge.test.js
@@ -1,70 +1,53 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { afterEach, describe, it, expect, beforeEach, vi } from 'vitest';
+import { setupJSDOM, teardownJSDOM } from '../setup/jsdom-helper.js';
 
 describe('gridRenderer edge cases', () => {
+  let dom;
+  let originalTimezone;
+
   beforeEach(async () => {
-    // Reset module cache so we can inject a fresh global `dateFns` mock before importing the renderer.
     vi.resetModules();
-
-    // Create a JSDOM document/window so DOM APIs are available in Node test environment.
-    const { JSDOM } = await import('jsdom');
-    const dom = new JSDOM('<!doctype html><html><body></body></html>');
-    // Expose minimal globals used by the renderer and tests
-    global.window = dom.window;
-    global.document = dom.window.document;
-    global.HTMLElement = dom.window.HTMLElement;
-    global.Node = dom.window.Node;
-
-    // Minimal date-fns mock implementing only functions used by renderAgeGrid for this test.
-    // The mock intentionally returns 54 weeks for eachWeekOfInterval so we can verify the code
-    // enforces a maximum visual row length of 53 by removing the last week.
-    global.dateFns = {
-      startOfDay: (d) => new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())),
-      startOfISOWeek: (d) => {
-        const dt = new Date(d);
-        const day = dt.getUTCDay(); // 0 (Sun) .. 6 (Sat)
-        // ISO week starts on Monday (1). Compute diff to Monday.
-        const diff = (day === 0 ? -6 : 1) - day;
-        return new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth(), dt.getUTCDate() + diff));
-      },
-      addYears: (d, n) => new Date(Date.UTC(d.getUTCFullYear() + n, d.getUTCMonth(), d.getUTCDate())),
-      eachWeekOfInterval: ({ start, end: _end }) => {
-        // Produce an array of 54 consecutive week-start dates beginning at `start`.
-        const weeks = [];
-        for (let i = 0; i < 54; i++) {
-          const dt = new Date(start);
-          dt.setUTCDate(dt.getUTCDate() + i * 7);
-          weeks.push(new Date(Date.UTC(dt.getUTCFullYear(), dt.getUTCMonth(), dt.getUTCDate())));
-        }
-        return weeks;
-      },
-      isBefore: (a, b) => a.getTime() < b.getTime(),
-      isAfter: (a, b) => a.getTime() > b.getTime(),
-      format: (d, _fmt) => {
-        const y = d.getUTCFullYear();
-        const m = String(d.getUTCMonth() + 1).padStart(2, '0');
-        const day = String(d.getUTCDate()).padStart(2, '0');
-        return `${y}-${m}-${day}`;
-      }
-    };
+    originalTimezone = process.env.TZ;
+    dom = await setupJSDOM();
   });
 
-  it('renderAgeGrid enforces max 53 weeks when eachWeekOfInterval yields 54', async () => {
-    // Import after setting the mock
-    const { renderAgeGrid } = await import('../../js/gridRenderer.js');
+  afterEach(() => {
+    if (originalTimezone === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTimezone;
+    teardownJSDOM(dom);
+    vi.useRealTimers();
+  });
 
-    // Create a container element (jsdom)
+  it('renderAgeGrid enforces max 53 weeks for a natural 54-week span', async () => {
+    const { renderAgeGrid } = await import('../../js/gridRenderer.js');
     const container = document.createElement('div');
 
-    // Choose a birth date and request 1 year of rendering so only age 0 row is generated
-    const birthDateUTC = new Date(Date.UTC(2000, 0, 1));
+    const birthDateUTC = new Date(Date.UTC(1903, 2, 1));
     renderAgeGrid(birthDateUTC, 1, container);
 
-    // Find the row for age 0
     const ageRow = container.querySelector('.year-row[data-age="0"]');
     expect(ageRow).toBeTruthy();
-
-    // Expect 53 week-block children (the renderer should remove the 54th)
     const weekBlocks = ageRow.querySelectorAll('.week-block');
     expect(weekBlocks.length).toBe(53);
+  });
+
+  it('marks the current local week in the age grid across a UTC rollover', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-06T01:00:00Z'));
+    const { renderAgeGrid } = await import('../../js/gridRenderer.js');
+
+    for (const [timezone, expectedStart] of [
+      ['America/Los_Angeles', '2024-12-30'],
+      ['UTC', '2025-01-06'],
+      ['Asia/Tokyo', '2025-01-06'],
+    ]) {
+      process.env.TZ = timezone;
+      const container = document.createElement('div');
+      renderAgeGrid(new Date('2023-07-01T00:00:00Z'), 3, container);
+
+      expect(container.querySelectorAll('.present')).toHaveLength(1);
+      expect(container.querySelector('.present')?.title)
+        .toContain(`Starts UTC: ${expectedStart}`);
+    }
   });
 });

--- a/tests/unit/gridRenderer.failure.test.js
+++ b/tests/unit/gridRenderer.failure.test.js
@@ -1,117 +1,64 @@
-/**
- * tests/unit/gridRenderer.failure.test.js
- *
- * Tests for renderer failure modes (missing dateFns, renderer errors)
- */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupJSDOM, teardownJSDOM } from '../setup/jsdom-helper.js';
 
-describe('gridRenderer failure modes', () => {
+describe('gridRenderer runtime and failure modes', () => {
+  let dom;
+
   beforeEach(async () => {
     vi.resetModules();
-    // Create a JSDOM document/window so DOM APIs are available in Node test environment.
-    const { JSDOM } = await import('jsdom');
-    const dom = new JSDOM('<!doctype html><html><body></body></html>');
-    global.window = dom.window;
-    global.document = dom.window.document;
-    global.HTMLElement = dom.window.HTMLElement;
-    global.Node = dom.window.Node;
-
     vi.useFakeTimers();
-    // Freeze time
-    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
-    // Ensure no global.dateFns is present
-    if (global.dateFns) delete global.dateFns;
+    vi.setSystemTime(new Date('2025-01-01T12:00:00Z'));
+    dom = await setupJSDOM();
   });
 
   afterEach(() => {
+    teardownJSDOM(dom);
     vi.useRealTimers();
     vi.restoreAllMocks();
-    if (global.dateFns) delete global.dateFns;
-    // Clean up DOM globals
-    if (global.window) delete global.window;
-    if (global.document) delete global.document;
-    if (global.HTMLElement) delete global.HTMLElement;
-    if (global.Node) delete global.Node;
   });
 
-  it('shows an error message in the DOM when dateFns is missing for calendar renderer', async () => {
-    const { renderCalendarGrid } = await import('../../js/gridRenderer.js');
-    const container = document.createElement('div');
-    const birthDateUTC = new Date(Date.UTC(2000, 0, 1));
-    renderCalendarGrid(birthDateUTC, 1, container);
-    const err = container.querySelector('.error-message');
-    expect(err).not.toBeNull();
-    expect(err.textContent).toContain('Error: Date library failed to load');
+  it('renders every view without external date-library globals', async () => {
+    const renderers = await import('../../js/gridRenderer.js');
+    const birthDateUTC = new Date('2000-01-01T00:00:00Z');
+
+    for (const renderer of [
+      renderers.renderAgeGrid,
+      renderers.renderCalendarGrid,
+      renderers.renderMonthsGrid,
+      renderers.renderYearsGrid,
+    ]) {
+      const container = document.createElement('div');
+      renderer(birthDateUTC, 1, container);
+      expect(container.hasChildNodes()).toBe(true);
+      expect(container.querySelector('.error-message')).toBeNull();
+    }
   });
 
-  it('shows an error message in the DOM when dateFns is missing for age renderer', async () => {
-    const { renderAgeGrid } = await import('../../js/gridRenderer.js');
-    const container = document.createElement('div');
-    const birthDateUTC = new Date(Date.UTC(2000, 0, 1));
-    renderAgeGrid(birthDateUTC, 1, container);
-    const err = container.querySelector('.error-message');
-    expect(err).not.toBeNull();
-    expect(err.textContent).toContain('Error: Date library failed to load');
+  it('returns safely when a grid container is not provided', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const renderers = await import('../../js/gridRenderer.js');
+    const birthDateUTC = new Date('2000-01-01T00:00:00Z');
+
+    expect(() => renderers.renderAgeGrid(birthDateUTC, 1, null)).not.toThrow();
+    expect(() => renderers.renderCalendarGrid(birthDateUTC, 1, null)).not.toThrow();
+    expect(() => renderers.renderMonthsGrid(birthDateUTC, 1, null)).not.toThrow();
+    expect(() => renderers.renderYearsGrid(birthDateUTC, 1, null)).not.toThrow();
+    expect(errorSpy).toHaveBeenCalledTimes(4);
   });
 
-  it('shows an error message in the DOM when dateFns is missing for months renderer', async () => {
+  it('shows an error message when a renderer encounters invalid date behavior', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { renderMonthsGrid } = await import('../../js/gridRenderer.js');
     const container = document.createElement('div');
-    const birthDateUTC = new Date(Date.UTC(2000, 0, 1));
-    renderMonthsGrid(birthDateUTC, 1, container);
-    const err = container.querySelector('.error-message');
-    expect(err).not.toBeNull();
-    expect(err.textContent).toContain('Error: Date library failed to load');
-  });
-
-  it('shows an error message when months renderer throws unexpectedly', async () => {
-    global.dateFns = {
-      startOfDay: (date) => date,
-    };
-
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { renderMonthsGrid } = await import('../../js/gridRenderer.js');
-    const container = document.createElement('div');
-    const invalidBirthDate = new Date(Date.UTC(2000, 0, 1));
+    const invalidBirthDate = new Date('2000-01-01T00:00:00Z');
     invalidBirthDate.getUTCMonth = () => {
       throw new Error('forced months failure');
     };
 
     renderMonthsGrid(invalidBirthDate, 1, container);
 
-    const err = container.querySelector('.error-message');
-    expect(err).not.toBeNull();
-    expect(err.textContent).toContain('Error generating months-based grid.');
-    expect(errSpy).toHaveBeenCalled();
-  });
-
-  it('shows an error message in the DOM when dateFns is missing for years renderer', async () => {
-    const { renderYearsGrid } = await import('../../js/gridRenderer.js');
-    const container = document.createElement('div');
-    const birthDateUTC = new Date(Date.UTC(2000, 0, 1));
-    renderYearsGrid(birthDateUTC, 1, container);
-    const err = container.querySelector('.error-message');
-    expect(err).not.toBeNull();
-    expect(err.textContent).toContain('Error: Date library failed to load');
-  });
-
-  it('shows an error message when calendar renderer throws unexpectedly', async () => {
-    global.dateFns = {
-      startOfDay: () => {
-        throw new Error('forced calendar failure');
-      },
-    };
-
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { renderCalendarGrid } = await import('../../js/gridRenderer.js');
-    const container = document.createElement('div');
-    const birthDateUTC = new Date(Date.UTC(2000, 0, 1));
-
-    renderCalendarGrid(birthDateUTC, 1, container);
-
-    const err = container.querySelector('.error-message');
-    expect(err).not.toBeNull();
-    expect(err.textContent).toContain('Error generating calendar-based grid.');
-    expect(errSpy).toHaveBeenCalled();
+    expect(container.querySelector('.error-message')?.textContent)
+      .toContain('Error generating months-based grid.');
+    expect(errorSpy).toHaveBeenCalled();
   });
 });

--- a/tests/unit/gridRenderer.months.test.js
+++ b/tests/unit/gridRenderer.months.test.js
@@ -12,7 +12,6 @@ const TEST_TIMEZONES = [
 describe('gridRenderer months view', () => {
   let dom;
   let originalTimezone;
-  let localDateOperation;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -21,26 +20,11 @@ describe('gridRenderer months view', () => {
     dom = await setupJSDOM();
     originalTimezone = process.env.TZ;
 
-    localDateOperation = vi.fn(() => {
-      throw new Error('renderer used a local-time date-fns operation');
-    });
-    global.dateFns = {
-      startOfDay: localDateOperation,
-      startOfMonth: localDateOperation,
-      addMonths: localDateOperation,
-      addYears: localDateOperation,
-      isAfter: localDateOperation,
-      isBefore: localDateOperation,
-      format: localDateOperation,
-      version: '4.1.0-test',
-    };
   });
 
   afterEach(() => {
     if (originalTimezone === undefined) delete process.env.TZ;
     else process.env.TZ = originalTimezone;
-    delete global.dateFns;
-    delete global.dateFnsTz;
     teardownJSDOM(dom);
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -65,8 +49,6 @@ describe('gridRenderer months view', () => {
       expect(container.querySelector('.present').title).toContain('Starts UTC: 2025-07-01');
       expect(container.querySelectorAll('.future')).toHaveLength(5);
     }
-
-    expect(localDateOperation).not.toHaveBeenCalled();
   });
 
   it('renders the exact fractional-lifespan month count without duplicate boundaries', async () => {
@@ -80,7 +62,6 @@ describe('gridRenderer months view', () => {
     expect(blocks).toHaveLength(Math.ceil(0.25 * 12));
     expect(starts).toEqual(['2000-01-01', '2000-02-01', '2000-03-01']);
     expect(new Set(starts).size).toBe(starts.length);
-    expect(localDateOperation).not.toHaveBeenCalled();
   });
 
   it('assigns life stages from corrected UTC month starts', async () => {
@@ -95,5 +76,23 @@ describe('gridRenderer months view', () => {
     expect(blocks[12].classList.contains('stage-infancy')).toBe(true);
     expect(blocks[13].title).toContain('Starts UTC: 2001-02-01');
     expect(blocks[13].classList.contains('stage-toddler')).toBe(true);
+  });
+
+  it('marks the current local month across a UTC year rollover', async () => {
+    const { renderMonthsGrid } = await import('../../js/gridRenderer.js');
+    vi.setSystemTime(new Date('2025-01-01T01:00:00Z'));
+
+    for (const [timezone, expectedStart] of [
+      ['America/Los_Angeles', '2024-12-01'],
+      ['UTC', '2025-01-01'],
+      ['Asia/Tokyo', '2025-01-01'],
+    ]) {
+      process.env.TZ = timezone;
+      const container = document.createElement('div');
+      renderMonthsGrid(new Date('2024-01-01T00:00:00Z'), 2, container);
+
+      expect(container.querySelectorAll('.present')).toHaveLength(1);
+      expect(container.querySelector('.present')?.title).toContain(`Starts UTC: ${expectedStart}`);
+    }
   });
 });

--- a/tests/unit/gridRenderer.years.test.js
+++ b/tests/unit/gridRenderer.years.test.js
@@ -12,7 +12,6 @@ const TEST_TIMEZONES = [
 describe('gridRenderer years view', () => {
   let dom;
   let originalTimezone;
-  let localDateOperation;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -21,24 +20,11 @@ describe('gridRenderer years view', () => {
     dom = await setupJSDOM();
     originalTimezone = process.env.TZ;
 
-    localDateOperation = vi.fn(() => {
-      throw new Error('renderer used a local-time date-fns operation');
-    });
-    global.dateFns = {
-      startOfDay: localDateOperation,
-      addYears: localDateOperation,
-      isAfter: localDateOperation,
-      isBefore: localDateOperation,
-      format: localDateOperation,
-      version: '4.1.0-test',
-    };
   });
 
   afterEach(() => {
     if (originalTimezone === undefined) delete process.env.TZ;
     else process.env.TZ = originalTimezone;
-    delete global.dateFns;
-    delete global.dateFnsTz;
     teardownJSDOM(dom);
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -63,8 +49,6 @@ describe('gridRenderer years view', () => {
         .toBe('Age 35 (Starts UTC: 2025-06-15) (Current year)');
       expect(container.querySelectorAll('.future')).toHaveLength(4);
     }
-
-    expect(localDateOperation).not.toHaveBeenCalled();
   });
 
   it('preserves the existing fractional-lifespan year block count', async () => {
@@ -77,7 +61,6 @@ describe('gridRenderer years view', () => {
     expect(blocks).toHaveLength(Math.ceil(2.5));
     expect(blocks.map((block) => block.title.match(/Starts UTC: ([0-9-]+)/)?.[1]))
       .toEqual(['2000-01-01', '2001-01-01', '2002-01-01']);
-    expect(localDateOperation).not.toHaveBeenCalled();
   });
 
   it('uses February 28 for leap-day anniversaries in non-leap years', async () => {
@@ -92,5 +75,23 @@ describe('gridRenderer years view', () => {
       .toEqual(['2000-02-29', '2001-02-28', '2002-02-28', '2003-02-28', '2004-02-29']);
     expect(container.querySelector('.present').title)
       .toBe('Age 25 (Starts UTC: 2025-02-28) (Current year)');
+  });
+
+  it('marks the current local age year across a UTC year rollover', async () => {
+    const { renderYearsGrid } = await import('../../js/gridRenderer.js');
+    vi.setSystemTime(new Date('2025-01-01T01:00:00Z'));
+
+    for (const [timezone, expectedAge] of [
+      ['America/Los_Angeles', 24],
+      ['UTC', 25],
+      ['Asia/Tokyo', 25],
+    ]) {
+      process.env.TZ = timezone;
+      const container = document.createElement('div');
+      renderYearsGrid(new Date('2000-01-01T00:00:00Z'), 30, container);
+
+      expect(container.querySelectorAll('.present')).toHaveLength(1);
+      expect(container.querySelector('.present')?.title).toContain(`Age ${expectedAge}`);
+    }
   });
 });

--- a/tests/unit/timezone.integration.test.js
+++ b/tests/unit/timezone.integration.test.js
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupJSDOM, teardownJSDOM } from '../setup/jsdom-helper.js';
+
+describe('timezone calculation integration', () => {
+  let dom;
+  let originalTimezone;
+
+  beforeEach(async () => {
+    originalTimezone = process.env.TZ;
+    process.env.TZ = 'America/Los_Angeles';
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-28T12:00:00Z'));
+    dom = await setupJSDOM(`
+      <!doctype html>
+      <html>
+        <body>
+          <form id="life-input-form">
+            <input id="birthdate">
+            <select id="sex">
+              <option value="">Select</option>
+              <option value="female">Female</option>
+            </select>
+            <button id="calculate-btn" type="submit">Calculate & Visualize</button>
+          </form>
+          <div id="results-area" class="hidden"></div>
+          <div id="life-grid-container" class="hidden">
+            <div id="grid-controls-header">
+              <div id="view-switcher">
+                <button
+                  class="view-button active"
+                  id="view-weeks-age"
+                  role="tab"
+                  data-view="weeks-age"
+                  aria-selected="true"
+                  tabindex="0"
+                >Weeks (Age)</button>
+              </div>
+            </div>
+            <div id="grid-axis-label-top"></div>
+            <div id="grid-content-wrapper">
+              <div id="grid-axis-label-left"></div>
+              <div id="grid-content-area"></div>
+            </div>
+          </div>
+          <div id="start-over-container" class="hidden">
+            <button id="start-over-btn" type="button">Start Over</button>
+          </div>
+        </body>
+      </html>
+    `);
+  });
+
+  afterEach(() => {
+    if (originalTimezone === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTimezone;
+    teardownJSDOM(dom);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('calculates and renders through the real module graph', async () => {
+    const { setupEventListeners } = await import('../../js/ui.js');
+    setupEventListeners();
+
+    const form = document.getElementById('life-input-form');
+    const birthdateInput = document.getElementById('birthdate');
+    const sexSelect = document.getElementById('sex');
+    const resultsArea = document.getElementById('results-area');
+    const gridContentArea = document.getElementById('grid-content-area');
+
+    expect(birthdateInput.max).toBe('2026-07-27');
+
+    birthdateInput.value = '1990-06-15';
+    birthdateInput.dispatchEvent(new Event('input', { bubbles: true }));
+    sexSelect.value = 'female';
+    sexSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    await vi.waitFor(() => {
+      expect(resultsArea.textContent).toContain('36 years');
+      expect(gridContentArea.querySelectorAll('.week-block').length).toBeGreaterThan(0);
+    });
+
+    expect(gridContentArea.querySelectorAll('.present')).toHaveLength(1);
+    expect(gridContentArea.querySelector('.error-message')).toBeNull();
+    expect(document.getElementById('life-grid-container').classList.contains('hidden')).toBe(false);
+  });
+});

--- a/tests/unit/ui.test.js
+++ b/tests/unit/ui.test.js
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 describe('ui module (setup & form flow)', () => {
+  let originalTimezone;
+
   beforeEach(async () => {
+    originalTimezone = process.env.TZ;
     // Reset modules so mocks apply to imports performed by ui.js
     vi.resetModules();
 
@@ -79,7 +82,7 @@ describe('ui module (setup & form flow)', () => {
       };
     });
 
-    // Mock the gridRenderer functions so renderCurrentView does not depend on date-fns
+    // Mock grid renderers so UI tests stay focused on orchestration.
     vi.doMock('../../js/gridRenderer.js', async () => {
       return {
         renderAgeGrid: vi.fn(() => {}),
@@ -91,6 +94,8 @@ describe('ui module (setup & form flow)', () => {
   });
 
   afterEach(() => {
+    if (originalTimezone === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTimezone;
     vi.useRealTimers();
     vi.restoreAllMocks();
     // Clean up globals
@@ -165,6 +170,37 @@ describe('ui module (setup & form flow)', () => {
     birthdateInput.dispatchEvent(new global.Event('input', { bubbles: true }));
     expect(calculateBtn.disabled).toBe(false);
   });
+
+  it.each([
+    ['America/Los_Angeles', '2026-01-01T01:00:00Z', '2025-12-30', '2025-12-31'],
+    ['Asia/Tokyo', '2026-01-01T01:00:00Z', '2025-12-31', '2026-01-01'],
+  ])(
+    'validates birthdates against the local calendar in %s',
+    async (timezone, instant, expectedMaximum, localToday) => {
+      process.env.TZ = timezone;
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(instant));
+
+      const { setupEventListeners } = await import('../../js/ui.js');
+      setupEventListeners();
+
+      const birthdateInput = document.getElementById('birthdate');
+      const sexSelect = document.getElementById('sex');
+      const calculateBtn = document.getElementById('calculate-btn');
+      sexSelect.value = 'male';
+      sexSelect.dispatchEvent(new global.Event('change', { bubbles: true }));
+
+      expect(birthdateInput.max).toBe(expectedMaximum);
+
+      birthdateInput.value = localToday;
+      birthdateInput.dispatchEvent(new global.Event('input', { bubbles: true }));
+      expect(calculateBtn.disabled).toBe(true);
+
+      birthdateInput.value = expectedMaximum;
+      birthdateInput.dispatchEvent(new global.Event('input', { bubbles: true }));
+      expect(calculateBtn.disabled).toBe(false);
+    },
+  );
 
   it('handleCalculation success path displays results, hides form, and reveals grid', async () => {
     const { setupEventListeners } = await import('../../js/ui.js');

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,2 +1,0 @@
-declare const dateFns: any;
-declare const dateFnsTz: any;


### PR DESCRIPTION
## Summary

- add one shared native date-only model for browser-local “today” and deterministic UTC-encoded boundaries
- make age and current week/month/year state change on the user's local calendar
- replace remaining CDN-global `date-fns` / `date-fns-tz` runtime use
- add representative timezone, DST, leap-day, UTC-rollover, ISO 52/53-week, and real-module integration coverage
- document why native helpers were the focused no-build fix and track maintained-library reconsideration separately

## Root cause

The maintained libraries were not themselves defective. The application mixed local-time library operations with UTC-encoded date-only values and relied on CDN globals, including a `date-fns-tz` global that was unavailable in the audited browser runtime.

## Commits

- `58479e0 fix(date): use local calendar timezone semantics`
- `54836e3 test(date): cover worldwide timezone boundaries`
- `b348e1c docs(date): record timezone architecture decision`

## Validation

- `conda run -n base npm run verify`
  - 13 test files
  - 87 tests passing
- `conda run -n base npm run test:coverage`
  - 97.96% statements
  - 87.09% branches
  - 100% functions
  - 98.15% lines
- shuffled suite passed with seed `40721`
- Pacific-time browser verification:
  - deterministic calculation completed without console or CDN errors
  - all four views rendered with exactly one present-period block
  - Start Over restored initial inputs, visibility, Calculate state, and Weeks (Age)

## Follow-up

- #40 investigates maintained date libraries, module delivery, and Temporal
- #41 tracks authoritative actuarial-data integrity checks
- #42 tracks fractional lifespan endpoint policy
- #43 tracks stronger production-page integration coverage
- #44 tracks stale and misleading test contracts

Fixes #35